### PR TITLE
Tst: Storage infrastructure refactor

### DIFF
--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -1,0 +1,20 @@
+# tests/factories/__init__.py
+"""Re-exports for test factories."""
+
+from .models import (
+    make_item,
+    make_link_item,
+    make_pic_item,
+    make_text_item,
+    make_write_plan,
+)
+from .payloads import gen_image
+
+__all__ = [
+    "make_item",
+    "make_link_item",
+    "make_pic_item",
+    "make_text_item",
+    "make_write_plan",
+    "gen_image",
+]

--- a/tests/factories/models.py
+++ b/tests/factories/models.py
@@ -1,13 +1,14 @@
-# tests/factories.py
-# Author: Marcus Grant
-# Date: 2026-01-09
-# License: Apache-2.0
+# tests/factories/models.py
+"""
+Factory functions for model instances.
+Author: Marcus Grant
+Date: 2026-01-26
+License: Apache-2.0
+"""
 
 from depo.model.enums import ContentFormat, ItemKind, PayloadKind, Visibility
 from depo.model.item import Item, LinkItem, PicItem, TextItem
 from depo.model.write_plan import WritePlan
-
-### Item Factories ###
 
 _ITEM_DEFAULTS = dict(
     code="ABC12345",
@@ -48,38 +49,20 @@ def make_pic_item(**overrides) -> PicItem:
     return PicItem(**(defaults | overrides))  # pyright: ignore[reportArgumentType]
 
 
-### WritePlan Factories ###
-
-_WRITE_PLAN_DEFAULTS = dict(
-    hash_full="ABC1234567890DEFGHKMNPQR",
-    code_min_len=8,
-    payload_kind=PayloadKind.BYTES,
-    kind=ItemKind.TEXT,
-    size_b=100,
-    upload_at=1234567890,
-    format=None,
-    origin_at=None,
-    payload_bytes=None,
-    payload_path=None,
-    width=None,
-    height=None,
-    link_url=None,
-)
-
-
 def make_write_plan(**overrides) -> WritePlan:
-    return WritePlan(**(_WRITE_PLAN_DEFAULTS | overrides))  # pyright: ignore[reportArgumentType]
-
-
-### Image Factories ###
-def gen_image(fmt: str, width: int, height: int) -> bytes:
-    """Generate minimal valid image bytes."""
-
-    from io import BytesIO
-
-    from PIL import Image
-
-    buf = BytesIO()
-    img = Image.new("RGB", (width, height), color=(255, 0, 0))
-    img.save(buf, format=fmt)
-    return buf.getvalue()
+    defaults = dict(
+        hash_full="ABC1234567890DEFGHKMNPQR",
+        code_min_len=8,
+        payload_kind=PayloadKind.BYTES,
+        kind=ItemKind.TEXT,
+        size_b=100,
+        upload_at=1234567890,
+        format=None,
+        origin_at=None,
+        payload_bytes=None,
+        payload_path=None,
+        width=None,
+        height=None,
+        link_url=None,
+    )
+    return WritePlan(**(defaults | overrides))  # pyright: ignore[reportArgumentType]

--- a/tests/factories/payloads.py
+++ b/tests/factories/payloads.py
@@ -1,0 +1,19 @@
+# tests/factories/payloads.py
+"""
+Factory functions for test payloads.
+Author: Marcus Grant
+Date: 2026-01-26
+License: Apache-2.0
+"""
+
+from io import BytesIO
+
+from PIL import Image
+
+
+def gen_image(fmt: str, width: int, height: int) -> bytes:
+    """Generate minimal valid image bytes."""
+    buf = BytesIO()
+    img = Image.new("RGB", (width, height), color=(255, 0, 0))
+    img.save(buf, format=fmt)
+    return buf.getvalue()

--- a/tests/fixtures/db.py
+++ b/tests/fixtures/db.py
@@ -1,0 +1,16 @@
+# tests/fixtures/db.py
+"""
+Database fixtures for repository testing.
+Author: Marcus Grant
+Date: 2026-01-26
+License: Apache-2.0
+"""
+
+import pytest
+
+
+@pytest.fixture
+def test_db():
+    """In-memory SQLite database with schema initialized."""
+    # TODO: Implement schema creation in PR 2 (repo read path)
+    raise NotImplementedError("test_db fixture not yet implemented")

--- a/tests/fixtures/storage.py
+++ b/tests/fixtures/storage.py
@@ -1,0 +1,23 @@
+# tests/fixtures/storage.py
+"""
+Storage fixtures for filesystem backend testing.
+Author: Marcus Grant
+Date: 2026-01-26
+License: Apache-2.0
+"""
+
+import pytest
+
+
+@pytest.fixture
+def test_storage_root():
+    """Temporary directory for storage tests."""
+    # TODO: Implement in PR 4 (storage layer)
+    raise NotImplementedError("test_storage_root fixture not yet implemented")
+
+
+@pytest.fixture
+def test_storage():
+    """FilesystemStorage instance with temporary root."""
+    # TODO: Implement in PR 4 (storage layer)
+    raise NotImplementedError("test_storage fixture not yet implemented")

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -1,0 +1,6 @@
+# tests/helpers/__init__.py
+"""Re-exports for test helpers."""
+
+from .assertions import assert_field
+
+__all__ = ["assert_field"]

--- a/tests/helpers/assertions.py
+++ b/tests/helpers/assertions.py
@@ -1,9 +1,8 @@
-# tests/helpers.py
+# tests/helpers/assertions.py
 """
-Helper functions for common testing procedures/patterns
-
+Assertion helpers for common testing patterns.
 Author: Marcus Grant
-Date: 2026-01-20
+Date: 2026-01-26
 License: Apache-2.0
 """
 


### PR DESCRIPTION
## Summary

Refactor test infrastructure to support
upcoming repo and storage layer testing.

## Changes

- Split `helpers.py` -> `helpers/` module with `assertions.py`
- Split `factories.py` -> `factories/` module with
  - `models.py` and `payloads.py`
- Add `fixtures/` stubs for
  - `test_db` and `test_storage`
  - *(NotImplementedError until implemented in upcoming PRs)*
- All re-exports preserve existing import paths

## Notes

No new test coverage — this is structural prep for upcoming PRs.
