### PR TITLE
Ft:Repo layer (read path)

### DIFF
--- a/doc/design/mvp.md
+++ b/doc/design/mvp.md
@@ -96,7 +96,7 @@ Storage model:
 
 - `hash_full` = complete 24-char hash (primary identity)
 - `code` = unique prefix (8-24 chars, assigned at creation)
-- Domain models derive `hash_rest = hash_full[len(code):]` at read time
+- Domain models store `hash_full` directly (matches DB schema)
 
 ### 3.3 Collision handling (prefix extension)
 
@@ -141,7 +141,7 @@ Storage model:
 #### Item Fields (domain model)
 
 - `code` (from DB)
-- `hash_rest` (derived: `hash_full[len(code):]`)
+- `hash_full` (content-addressed identity)
 - All other fields map directly
 
 ### 4.2 TextItem (heavy-load-bearing)

--- a/doc/design/patterns.md
+++ b/doc/design/patterns.md
@@ -206,9 +206,6 @@ YAGNI: don't abstract until the second case emerges.
 # DB stores
 hash_full = "ABCD1234XXXXXXXXXXXXXXXX"
 code = "ABCD1234"
-
-# Domain model derives
-hash_rest = hash_full[len(code):]  # "XXXXXXXXXXXXXXXX"
 ```
 
 Store canonical data. Derive redundant fields when mapping to domain model.

--- a/doc/module/model.md
+++ b/doc/module/model.md
@@ -18,7 +18,7 @@ ContentFormat values are canonical short extensions (e.g., `jpg` not `jpeg`).
 
 Frozen dataclasses with `kw_only=True`.
 
-**Item (base):** code, hash_rest, kind, size_b, upload_at, uid, perm, origin_at (optional)
+**Item (base):** code, hash_full, kind, size_b, upload_at, uid, perm, origin_at (optional)
 
 **TextItem(Item):** format (ContentFormat)
 

--- a/doc/module/repo.md
+++ b/doc/module/repo.md
@@ -137,11 +137,7 @@ def _row_to_pic_item(self, row: sqlite3.Row) -> PicItem: ...
 def _row_to_link_item(self, row: sqlite3.Row) -> LinkItem: ...
 ```
 
-Map DB rows to frozen domain models. Derive `hash_rest` from `hash_full` and `code`:
-
-```python
-hash_rest = row["hash_full"][len(row["code"]):]
-```
+Map DB rows to frozen domain models.
 
 ### Design decisions
 

--- a/src/depo/model/item.py
+++ b/src/depo/model/item.py
@@ -19,7 +19,7 @@ from depo.model.enums import ContentFormat, ItemKind, Visibility
 @dataclass(frozen=True, kw_only=True)
 class Item:
     code: str
-    hash_rest: str
+    hash_full: str
     kind: ItemKind
     size_b: int
     uid: int

--- a/src/depo/repo/schema.sql
+++ b/src/depo/repo/schema.sql
@@ -1,0 +1,7 @@
+-- src/depo/repo/schema.sql
+-- SQLite schema for depo item storage.
+-- Author: Marcus Grant
+-- Date: 2026-01-26
+-- License: Apache-2.0
+
+-- TODO: Implement tables (items, text_items, pic_items, link_items) and indexes

--- a/src/depo/repo/schema.sql
+++ b/src/depo/repo/schema.sql
@@ -4,4 +4,34 @@
 -- Date: 2026-01-26
 -- License: Apache-2.0
 
--- TODO: Implement tables (items, text_items, pic_items, link_items) and indexes
+CREATE TABLE IF NOT EXISTS items (
+    hash_full   TEXT PRIMARY KEY,
+    code        TEXT UNIQUE NOT NULL,
+    kind        TEXT NOT NULL,
+    size_b      INTEGER NOT NULL,
+    uid         INTEGER NOT NULL DEFAULT 0,
+    perm        TEXT NOT NULL DEFAULT 'pub',
+    upload_at   INTEGER NOT NULL,
+    origin_at   INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS text_items (
+    hash_full   TEXT PRIMARY KEY REFERENCES items(hash_full),
+    format      TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS pic_items (
+    hash_full   TEXT PRIMARY KEY REFERENCES items(hash_full),
+    format      TEXT NOT NULL,
+    width       INTEGER NOT NULL,
+    height      INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS link_items (
+    hash_full   TEXT PRIMARY KEY REFERENCES items(hash_full),
+    url         TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_items_uid ON items(uid);
+CREATE INDEX IF NOT EXISTS idx_items_kind ON items(kind);
+CREATE INDEX IF NOT EXISTS idx_items_upload ON items(upload_at);

--- a/src/depo/repo/sqlite.py
+++ b/src/depo/repo/sqlite.py
@@ -9,6 +9,9 @@ License: Apache-2.0
 import sqlite3
 from importlib import resources
 
+from depo.model.enums import ContentFormat, ItemKind, Visibility
+from depo.model.item import LinkItem, PicItem, TextItem
+
 
 def init_db(conn: sqlite3.Connection) -> None:
     """
@@ -19,3 +22,50 @@ def init_db(conn: sqlite3.Connection) -> None:
     """
     schema = resources.files("depo.repo").joinpath("schema.sql").read_text()
     conn.executescript(schema)
+
+
+def _row_to_text_item(row: sqlite3.Row) -> TextItem:
+    """Map joined items + text_items row to TextItem."""
+    return TextItem(
+        code=row["code"],
+        hash_full=row["hash_full"],
+        kind=ItemKind(row["kind"]),
+        size_b=row["size_b"],
+        uid=row["uid"],
+        upload_at=row["upload_at"],
+        origin_at=row["origin_at"],
+        perm=Visibility(row["perm"]),
+        format=ContentFormat(row["format"]),
+    )
+
+
+def _row_to_pic_item(row: sqlite3.Row) -> PicItem:
+    """Map joined items + pic_items row to PicItem."""
+    return PicItem(
+        code=row["code"],
+        hash_full=row["hash_full"],
+        kind=ItemKind(row["kind"]),
+        size_b=row["size_b"],
+        uid=row["uid"],
+        upload_at=row["upload_at"],
+        origin_at=row["origin_at"],
+        perm=Visibility(row["perm"]),
+        format=ContentFormat(row["format"]),
+        width=row["width"],
+        height=row["height"],
+    )
+
+
+def _row_to_link_item(row: sqlite3.Row) -> LinkItem:
+    """Map joined items + link_items row to LinkItem."""
+    return LinkItem(
+        code=row["code"],
+        hash_full=row["hash_full"],
+        kind=ItemKind(row["kind"]),
+        size_b=row["size_b"],
+        uid=row["uid"],
+        upload_at=row["upload_at"],
+        origin_at=row["origin_at"],
+        perm=Visibility(row["perm"]),
+        url=row["url"],
+    )

--- a/src/depo/repo/sqlite.py
+++ b/src/depo/repo/sqlite.py
@@ -6,8 +6,8 @@ Date: 2026-01-26
 License: Apache-2.0
 """
 
-from importlib import resources
 import sqlite3
+from importlib import resources
 
 
 def init_db(conn: sqlite3.Connection) -> None:
@@ -17,4 +17,5 @@ def init_db(conn: sqlite3.Connection) -> None:
     Args:
         conn: SQLite connection to initialize.
     """
-    raise NotImplementedError
+    schema = resources.files("depo.repo").joinpath("schema.sql").read_text()
+    conn.executescript(schema)

--- a/src/depo/repo/sqlite.py
+++ b/src/depo/repo/sqlite.py
@@ -1,0 +1,20 @@
+# src/depo/repo/sqlite.py
+"""
+SQLite implementation of item repository.
+Author: Marcus Grant
+Date: 2026-01-26
+License: Apache-2.0
+"""
+
+from importlib import resources
+import sqlite3
+
+
+def init_db(conn: sqlite3.Connection) -> None:
+    """
+    Apply schema to connection. Idempotent.
+
+    Args:
+        conn: SQLite connection to initialize.
+    """
+    raise NotImplementedError

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+# tests/conftest.py
+"""Pytest configuration and fixture loading."""
+
+import sqlite3
+
+import pytest
+
+pytest_plugins = [
+    "tests.fixtures.db",
+]
+
+
+@pytest.fixture
+def conn():
+    """Raw in-memory SQLite connection (no schema)."""
+    c = sqlite3.connect(":memory:")
+    yield c
+    c.close()

--- a/tests/factories/models.py
+++ b/tests/factories/models.py
@@ -12,7 +12,7 @@ from depo.model.write_plan import WritePlan
 
 _ITEM_DEFAULTS = dict(
     code="ABC12345",
-    hash_rest="06789DEFGHKMNPQR",
+    hash_full="ABC1234506789DEFGHKMNPQR",
     kind=ItemKind.TEXT,
     size_b=100,
     uid=1,

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,0 +1,13 @@
+# tests/fixtures/__init__.py
+"""Re-exports for test fixtures."""
+
+from .db import test_db
+
+# TODO: Uncomment as implemented
+# from .storage import test_storage, test_storage_root
+
+__all__ = [
+    "test_db",
+    # "test_storage",
+    # "test_storage_root",
+]

--- a/tests/fixtures/db.py
+++ b/tests/fixtures/db.py
@@ -6,11 +6,18 @@ Date: 2026-01-26
 License: Apache-2.0
 """
 
+import sqlite3
+from collections.abc import Generator
+
 import pytest
+
+from depo.repo.sqlite import init_db
 
 
 @pytest.fixture
-def test_db():
+def test_db() -> Generator[sqlite3.Connection, None, None]:
     """In-memory SQLite database with schema initialized."""
-    # TODO: Implement schema creation in PR 2 (repo read path)
-    raise NotImplementedError("test_db fixture not yet implemented")
+    conn = sqlite3.connect(":memory:")
+    init_db(conn)
+    yield conn
+    conn.close()

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -1,6 +1,6 @@
 # tests/helpers/__init__.py
 """Re-exports for test helpers."""
 
-from .assertions import assert_field
+from .assertions import assert_column, assert_field, assert_item_base_fields
 
-__all__ = ["assert_field"]
+__all__ = ["assert_column", "assert_field", "assert_item_base_fields"]

--- a/tests/helpers/assertions.py
+++ b/tests/helpers/assertions.py
@@ -6,6 +6,7 @@ Date: 2026-01-26
 License: Apache-2.0
 """
 
+import sqlite3
 from dataclasses import MISSING, fields
 from typing import Any
 
@@ -42,3 +43,46 @@ def assert_field(cls: type, name: str, typ: type, required: bool, default: Any) 
     else:
         msg = f"{name} default mismatch: expected {default}, got {f.default}"
         assert f.default == default, msg
+
+
+### Database Assertions ###
+def assert_column(
+    conn: sqlite3.Connection,
+    table: str,
+    name: str,
+    typ: str,
+    *,
+    notnull: bool = False,
+    default: Any = None,
+    pk: bool = False,
+) -> None:
+    """
+    Assert a SQLite table column has expected properties.
+
+    Args:
+        conn: SQLite connection.
+        table: Table name.
+        name: Column name.
+        typ: Expected type (TEXT, INTEGER, etc.).
+        notnull: If True, column must be NOT NULL.
+        default: Expected default value (None if no default).
+        pk: If True, column must be PRIMARY KEY.
+
+    Raises:
+        AssertionError: If any expectation is not met.
+    """
+    cursor = conn.execute(f"PRAGMA table_info({table})")
+    columns = {row[1]: row for row in cursor.fetchall()}
+    # row: (cid, name, type, notnull, dflt_value, pk)
+
+    assert name in columns, f"missing column: {name}"
+    row = columns[name]
+
+    assert row[2] == typ, f"{name} type mismatch: expected {typ}, got {row[2]}"
+    assert row[3] == int(notnull), (
+        f"{name} notnull mismatch: expected {notnull}, got {bool(row[3])}"
+    )
+    assert row[4] == default, (
+        f"{name} default mismatch: expected {default}, got {row[4]}"
+    )
+    assert row[5] == int(pk), f"{name} pk mismatch: expected {pk}, got {bool(row[5])}"

--- a/tests/helpers/assertions.py
+++ b/tests/helpers/assertions.py
@@ -10,6 +10,9 @@ import sqlite3
 from dataclasses import MISSING, fields
 from typing import Any
 
+from depo.model.item import Item
+from depo.model.enums import ItemKind, Visibility
+
 
 def assert_field(cls: type, name: str, typ: type, required: bool, default: Any) -> None:
     """
@@ -86,3 +89,45 @@ def assert_column(
         f"{name} default mismatch: expected {default}, got {row[4]}"
     )
     assert row[5] == int(pk), f"{name} pk mismatch: expected {pk}, got {bool(row[5])}"
+
+
+def assert_item_base_fields(
+    item: Item,
+    *,
+    code: str,
+    hash_full: str,
+    kind: ItemKind,
+    size_b: int,
+    uid: int,
+    perm: Visibility,
+    upload_at: int,
+    origin_at: int | None,
+) -> None:
+    """
+    Assert an Item has expected base field values.
+
+    Args:
+        item: Item instance (or subclass).
+        code: Expected code.
+        hash_full: Expected hash_full.
+        kind: Expected ItemKind.
+        size_b: Expected size in bytes.
+        uid: Expected user ID.
+        perm: Expected Visibility.
+        upload_at: Expected upload timestamp.
+        origin_at: Expected origin timestamp (may be None).
+
+    Raises:
+        AssertionError: If any field doesn't match.
+    """
+    assert item.code == code, f"code: expected {code}, got {item.code}"
+    msg = f"hash_full: expected {hash_full}, got {item.hash_full}"
+    assert item.hash_full == hash_full, msg
+    assert item.kind == kind, f"kind: expected {kind}, got {item.kind}"
+    assert item.size_b == size_b, f"size_b: expected {size_b}, got {item.size_b}"
+    assert item.uid == uid, f"uid: expected {uid}, got {item.uid}"
+    assert item.perm == perm, f"perm: expected {perm}, got {item.perm}"
+    msg = f"upload_at: expected {upload_at}, got {item.upload_at}"
+    assert item.upload_at == upload_at, msg
+    msg = f"origin_at: expected {origin_at}, got {item.origin_at}"
+    assert item.origin_at == origin_at, msg

--- a/tests/helpers/assertions.py
+++ b/tests/helpers/assertions.py
@@ -10,8 +10,8 @@ import sqlite3
 from dataclasses import MISSING, fields
 from typing import Any
 
-from depo.model.item import Item
 from depo.model.enums import ItemKind, Visibility
+from depo.model.item import Item
 
 
 def assert_field(cls: type, name: str, typ: type, required: bool, default: Any) -> None:

--- a/tests/helpers/test_assertions.py
+++ b/tests/helpers/test_assertions.py
@@ -8,10 +8,9 @@ License: Apache-2.0
 
 import pytest
 
-from tests.helpers.assertions import assert_column, assert_item_base_fields
-from tests.factories import make_item
-
 from depo.model.enums import ItemKind, Visibility
+from tests.factories import make_item
+from tests.helpers.assertions import assert_column, assert_item_base_fields
 
 
 class TestAssertColumn:

--- a/tests/helpers/test_assertions.py
+++ b/tests/helpers/test_assertions.py
@@ -1,0 +1,74 @@
+# tests/helpers/test_assertions.py
+"""
+Tests for assertion helpers.
+Author: Marcus Grant
+Date: 2026-01-26
+License: Apache-2.0
+"""
+
+import pytest
+
+from tests.helpers.assertions import assert_column
+
+
+class TestAssertColumn:
+    """Tests for assert_column()."""
+
+    def test_pass_for_matching_name_and_type(self, conn):
+        """passes for column with matching name and type"""
+        conn.execute("CREATE TABLE t (id INTEGER)")
+        assert_column(conn, "t", "id", "INTEGER")
+
+    def test_fail_for_nonexistent_column(self, conn):
+        """fails for nonexistent column"""
+        conn.execute("CREATE TABLE t (id INTEGER)")
+        with pytest.raises(AssertionError, match="missing column"):
+            assert_column(conn, "t", "missing", "INTEGER")
+
+    def test_fail_for_wrong_type(self, conn):
+        """fails for wrong type"""
+        conn.execute("CREATE TABLE t (id INTEGER)")
+        with pytest.raises(AssertionError, match="type mismatch"):
+            assert_column(conn, "t", "id", "TEXT")
+
+    def test_pass_for_notnull_column(self, conn):
+        """passes for NOT NULL column when notnull=True"""
+        conn.execute("CREATE TABLE t (id INTEGER NOT NULL)")
+        assert_column(conn, "t", "id", "INTEGER", notnull=True)
+
+    def test_fail_for_nullable_when_notnull_expected(self, conn):
+        """fails for nullable column when notnull=True"""
+        conn.execute("CREATE TABLE t (id INTEGER)")
+        with pytest.raises(AssertionError, match="notnull mismatch"):
+            assert_column(conn, "t", "id", "INTEGER", notnull=True)
+
+    def test_pass_for_matching_default(self, conn):
+        """passes for column with matching default value"""
+        conn.execute("CREATE TABLE t (id INTEGER DEFAULT 42)")
+        assert_column(conn, "t", "id", "INTEGER", default="42")
+
+    def test_fail_for_wrong_default(self, conn):
+        """fails for column with wrong default value"""
+        conn.execute("CREATE TABLE t (id INTEGER DEFAULT 42)")
+        with pytest.raises(AssertionError, match="default mismatch"):
+            assert_column(conn, "t", "id", "INTEGER", default="99")
+
+    def test_pass_for_pk_column(self, conn):
+        """passes for PRIMARY KEY column when pk=True"""
+        conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY)")
+        assert_column(conn, "t", "id", "INTEGER", pk=True)
+
+    def test_fail_for_non_pk_when_pk_expected(self, conn):
+        """fails for non-PK column when pk=True"""
+        conn.execute("CREATE TABLE t (id INTEGER)")
+        with pytest.raises(AssertionError, match="pk mismatch"):
+            assert_column(conn, "t", "id", "INTEGER", pk=True)
+
+    # fails for nonexistent column
+    # fails for wrong type
+    # passes for NOT NULL column when notnull=True
+    # fails for nullable column when notnull=True
+    # passes for column with matching default value
+    # fails for column with wrong default value
+    # passes for PRIMARY KEY column when pk=True
+    # fails for non-PK column when pk=True

--- a/tests/model/test_item.py
+++ b/tests/model/test_item.py
@@ -17,7 +17,7 @@ from depo.model.item import Item, LinkItem, PicItem, TextItem
 # "required": non-optional, "default": default value
 _ITEM_PARAMS = [
     ("code", str, True, None),
-    ("hash_rest", str, True, None),
+    ("hash_full", str, True, None),
     ("kind", ItemKind, True, None),
     ("size_b", int, True, None),
     ("uid", int, True, None),

--- a/tests/repo/test_sqlite.py
+++ b/tests/repo/test_sqlite.py
@@ -1,0 +1,27 @@
+# tests/repo/test_sqlite.py
+"""
+Tests for SqliteRepository.
+Author: Marcus Grant
+Date: 2026-01-26
+License: Apache-2.0
+"""
+
+import sqlite3
+
+import pytest
+
+from depo.repo.sqlite import init_db
+
+
+class TestInitDb:
+    """Tests for init_db()."""
+
+    def test_creates_items_table_and_cols(self, test_db: sqlite3.Connection):
+        """Creates items table with expected columns"""
+        ...
+
+    # Creates text_items table with expected columns
+    # Creates pic_items table with expected columns
+    # Creates link_items table with expected columns
+    # Creates expected indexes (idx_items_uid, idx_items_kind, idx_items_upload)
+    # Is idempotent (calling twice doesn't raise)

--- a/tests/repo/test_sqlite.py
+++ b/tests/repo/test_sqlite.py
@@ -6,9 +6,8 @@ Date: 2026-01-26
 License: Apache-2.0
 """
 
-import sqlite3
-
 import pytest
+from tests.helpers.assertions import assert_column
 
 from depo.repo.sqlite import init_db
 
@@ -16,12 +15,83 @@ from depo.repo.sqlite import init_db
 class TestInitDb:
     """Tests for init_db()."""
 
-    def test_creates_items_table_and_cols(self, test_db: sqlite3.Connection):
-        """Creates items table with expected columns"""
-        ...
+    @pytest.mark.parametrize(
+        "name, typ, notnull, default, pk",
+        [
+            ("hash_full", "TEXT", False, None, True),
+            ("code", "TEXT", True, None, False),
+            ("kind", "TEXT", True, None, False),
+            ("size_b", "INTEGER", True, None, False),
+            ("uid", "INTEGER", True, "0", False),
+            ("perm", "TEXT", True, "'pub'", False),
+            ("upload_at", "INTEGER", True, None, False),
+            ("origin_at", "INTEGER", False, None, False),
+        ],
+    )
+    def test_items_table_columns(self, test_db, name, typ, notnull, default, pk):
+        """items table has correct column definitions."""
+        assert_column(
+            test_db, "items", name, typ, notnull=notnull, default=default, pk=pk
+        )
 
-    # Creates text_items table with expected columns
-    # Creates pic_items table with expected columns
-    # Creates link_items table with expected columns
-    # Creates expected indexes (idx_items_uid, idx_items_kind, idx_items_upload)
-    # Is idempotent (calling twice doesn't raise)
+    @pytest.mark.parametrize(
+        ("name", "typ", "notnull", "default", "pk"),
+        [
+            ("hash_full", "TEXT", False, None, True),
+            ("format", "TEXT", True, None, False),
+        ],
+    )
+    def test_text_items_table_columns(self, test_db, name, typ, notnull, default, pk):
+        """text_items table has correct column definitions."""
+        assert_column(
+            test_db, "text_items", name, typ, notnull=notnull, default=default, pk=pk
+        )
+
+    @pytest.mark.parametrize(
+        ("name", "typ", "notnull", "default", "pk"),
+        [
+            ("hash_full", "TEXT", False, None, True),
+            ("format", "TEXT", True, None, False),
+            ("width", "INTEGER", True, None, False),
+            ("height", "INTEGER", True, None, False),
+        ],
+    )
+    def test_pic_items_table_columns(self, test_db, name, typ, notnull, default, pk):
+        """pic_items table has correct column definitions."""
+        assert_column(
+            test_db, "pic_items", name, typ, notnull=notnull, default=default, pk=pk
+        )
+
+    @pytest.mark.parametrize(
+        ("name", "typ", "notnull", "default", "pk"),
+        [
+            ("hash_full", "TEXT", False, None, True),
+            ("url", "TEXT", True, None, False),
+        ],
+    )
+    def test_link_items_table_columns(self, test_db, name, typ, notnull, default, pk):
+        """link_items table has correct column definitions."""
+        assert_column(
+            test_db, "link_items", name, typ, notnull=notnull, default=default, pk=pk
+        )
+
+    @pytest.mark.parametrize(
+        "index_name",
+        [
+            "idx_items_uid",
+            "idx_items_kind",
+            "idx_items_upload",
+        ],
+    )
+    def test_creates_indexes(self, test_db, index_name):
+        """init_db creates expected indexes."""
+        cursor = test_db.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' AND name=?",
+            (index_name,),
+        )
+        assert cursor.fetchone() is not None, f"missing index: {index_name}"
+
+    def test_idempotent(self, conn):
+        """Calling init_db twice doesn't raise."""
+        init_db(conn)
+        init_db(conn)  # Should not raise

--- a/tests/repo/test_sqlite.py
+++ b/tests/repo/test_sqlite.py
@@ -273,3 +273,63 @@ class TestGetByCode:
         result = repo.get_by_code("ABCD1234")
         assert isinstance(result, LinkItem)
         assert result.code == "ABCD1234"
+
+
+class TestGetByFullHash:
+    """Tests for SqliteRepository.get_by_full_hash()."""
+
+    def test_none_for_hash_not_exist(self, test_db):
+        """Returns None for nonexistent hash_full"""
+        repo = SqliteRepository(test_db)
+        assert repo.get_by_full_hash("0123456789ABCDEFGHJKMNPQ") is None
+
+    def test_text_item_for_item_hash(self, test_db):
+        """Returns correct TextItem for its 'hash_full' PK"""
+        test_db.execute(
+            "INSERT INTO items"
+            "(hash_full, code, kind, size_b, uid, perm, upload_at)"
+            "VALUES ('ABC1234506789DEFGHKMNPQR', 'ABCD1234',"
+            "'txt', 99, 0, 'prv', 123456789)"
+        )
+        test_db.execute(
+            "INSERT INTO text_items (hash_full, format)"
+            " VALUES ('ABC1234506789DEFGHKMNPQR', 'md')"
+        )
+        repo = SqliteRepository(test_db)
+        result = repo.get_by_full_hash("ABC1234506789DEFGHKMNPQR")
+        assert isinstance(result, TextItem)
+        assert result.hash_full == "ABC1234506789DEFGHKMNPQR"
+
+    def test_pic_item_for_item_hash(self, test_db):
+        """Returns correct PicItem for its 'hash_full' PK"""
+        test_db.execute(
+            "INSERT INTO items"
+            "(hash_full, code, kind, size_b, uid, perm, upload_at)"
+            "VALUES ('ABC1234506789DEFGHKMNPQR', 'ABCD1234',"
+            "'pic', 99, 0, 'prv', 123456789)"
+        )
+        test_db.execute(
+            "INSERT INTO pic_items (hash_full, format, width, height)"
+            " VALUES ('ABC1234506789DEFGHKMNPQR', 'png', 9, 16)"
+        )
+        repo = SqliteRepository(test_db)
+        result = repo.get_by_full_hash("ABC1234506789DEFGHKMNPQR")
+        assert isinstance(result, PicItem)
+        assert result.hash_full == "ABC1234506789DEFGHKMNPQR"
+
+    def test_link_item_for_item_hash(self, test_db):
+        """Returns correct LinkItem for its 'hash_full' PK"""
+        test_db.execute(
+            "INSERT INTO items"
+            "(hash_full, code, kind, size_b, uid, perm, upload_at)"
+            "VALUES ('ABC1234506789DEFGHKMNPQR', 'ABCD1234',"
+            "'url', 99, 0, 'prv', 123456789)"
+        )
+        test_db.execute(
+            "INSERT INTO link_items (hash_full, url)"
+            " VALUES ('ABC1234506789DEFGHKMNPQR', 'https://www.example.com')"
+        )
+        repo = SqliteRepository(test_db)
+        result = repo.get_by_full_hash("ABC1234506789DEFGHKMNPQR")
+        assert isinstance(result, LinkItem)
+        assert result.hash_full == "ABC1234506789DEFGHKMNPQR"

--- a/tests/repo/test_sqlite.py
+++ b/tests/repo/test_sqlite.py
@@ -6,10 +6,18 @@ Date: 2026-01-26
 License: Apache-2.0
 """
 
-import pytest
-from tests.helpers.assertions import assert_column
+import sqlite3
 
-from depo.repo.sqlite import init_db
+import pytest
+from tests.helpers import assert_column, assert_item_base_fields
+
+from depo.model.enums import ContentFormat, ItemKind, Visibility
+from depo.repo.sqlite import (
+    _row_to_link_item,
+    _row_to_pic_item,
+    _row_to_text_item,
+    init_db,
+)
 
 
 class TestInitDb:
@@ -95,3 +103,111 @@ class TestInitDb:
         """Calling init_db twice doesn't raise."""
         init_db(conn)
         init_db(conn)  # Should not raise
+
+
+class TestRowMappers:
+    """Tests for row mapper functions."""
+
+    def test_row_to_text_item(self, test_db):
+        """Maps all fields from joined row to TextItem."""
+        test_db.execute(
+            "INSERT INTO items"
+            " (hash_full, code, kind, size_b, uid, perm, upload_at, origin_at)"
+            " VALUES ('ABC1234506789DEFGHKMNPQR', 'ABC12345', 'txt', 100, 1, 'pub',"
+            " 1234567890, NULL)"
+        )
+        test_db.execute(
+            "INSERT INTO text_items (hash_full, format)"
+            " VALUES ('ABC1234506789DEFGHKMNPQR', 'txt')"
+        )
+        test_db.row_factory = sqlite3.Row
+        row = test_db.execute(
+            "SELECT i.*, t.format FROM items i"
+            " JOIN text_items t ON i.hash_full = t.hash_full"
+            " WHERE i.code = 'ABC12345'"
+        ).fetchone()
+
+        result = _row_to_text_item(row)
+
+        assert_item_base_fields(
+            result,
+            code="ABC12345",
+            hash_full="ABC1234506789DEFGHKMNPQR",
+            kind=ItemKind.TEXT,
+            size_b=100,
+            uid=1,
+            perm=Visibility.PUBLIC,
+            upload_at=1234567890,
+            origin_at=None,
+        )
+        assert result.format == ContentFormat.PLAINTEXT
+
+    def test_row_to_pic_item(self, test_db):
+        """Maps all fields from joined row to PicItem."""
+        test_db.execute(
+            "INSERT INTO items"
+            " (hash_full, code, kind, size_b, uid, perm, upload_at, origin_at)"
+            " VALUES ('ABC1234506789DEFGHKMNPQR', 'ABC12345', 'pic', 100, 1, 'pub',"
+            " 1234567890, NULL)"
+        )
+        test_db.execute(
+            "INSERT INTO pic_items (hash_full, format, width, height)"
+            " VALUES ('ABC1234506789DEFGHKMNPQR', 'png', 320, 240)"
+        )
+        test_db.row_factory = sqlite3.Row
+        row = test_db.execute(
+            "SELECT i.*, p.format, p.width, p.height FROM items i"
+            " JOIN pic_items p ON i.hash_full = p.hash_full"
+            " WHERE i.code = 'ABC12345'"
+        ).fetchone()
+
+        result = _row_to_pic_item(row)
+
+        assert_item_base_fields(
+            result,
+            code="ABC12345",
+            hash_full="ABC1234506789DEFGHKMNPQR",
+            kind=ItemKind.PICTURE,
+            size_b=100,
+            uid=1,
+            perm=Visibility.PUBLIC,
+            upload_at=1234567890,
+            origin_at=None,
+        )
+        assert result.format == ContentFormat.PNG
+        assert result.width == 320
+        assert result.height == 240
+
+    def test_row_to_link_item(self, test_db):
+        """Maps all fields from joined row to LinkItem."""
+        test_db.execute(
+            "INSERT INTO items"
+            " (hash_full, code, kind, size_b, uid, perm, upload_at, origin_at)"
+            " VALUES ('ABC1234506789DEFGHKMNPQR', 'ABC12345', 'url', 100, 1, 'pub',"
+            " 1234567890, NULL)"
+        )
+        test_db.execute(
+            "INSERT INTO link_items (hash_full, url)"
+            " VALUES ('ABC1234506789DEFGHKMNPQR', 'https://www.example.com')"
+        )
+        test_db.row_factory = sqlite3.Row
+        row = test_db.execute(
+            "SELECT i.*, l.url FROM items i"
+            " JOIN link_items l ON i.hash_full = l.hash_full"
+            " WHERE i.code = 'ABC12345'"
+        ).fetchone()
+
+        result = _row_to_link_item(row)
+
+        assert_item_base_fields(
+            result,
+            code="ABC12345",
+            hash_full="ABC1234506789DEFGHKMNPQR",
+            kind=ItemKind.LINK,
+            size_b=100,
+            uid=1,
+            perm=Visibility.PUBLIC,
+            upload_at=1234567890,
+            origin_at=None,
+        )
+        assert result.url == "https://www.example.com"

--- a/tests/repo/test_sqlite.py
+++ b/tests/repo/test_sqlite.py
@@ -176,7 +176,10 @@ class TestInitDb:
     def test_idempotent(self, conn):
         """Calling init_db twice doesn't raise."""
         init_db(conn)
+        _insert_text_item(conn)
         init_db(conn)  # Should not raise
+        row = conn.execute("SELECT * FROM items").fetchone()
+        assert row is not None
 
 
 class TestRowMappers:


### PR DESCRIPTION
## Summary

Implement SQLite repository with read operations for content-addressed items.

## Changes

- Add `schema.sql` with items + subtype tables, indexes
- Add `init_db()` for schema initialization (idempotent)
- Add row mappers for TextItem, PicItem, LinkItem
- Add `get_by_code()` for URL lookups
- Add `get_by_full_hash()` for dedupe checks
- Add `assert_column` and `assert_item_base_fields` test helpers
- Add _insert_{text,pic,link}_item test helpers

## Notes

Write path (`resolve_code`, `insert`) comes in repo PR.
