### PR TITLE
Ft: Repo layer (write path)

### DIFF
--- a/doc/design/mvp.md
+++ b/doc/design/mvp.md
@@ -303,13 +303,12 @@ class Repository(Protocol):
     def insert(
         self,
         plan: WritePlan,
-        code: str,
         *,
         uid: int = 0,
         perm: Visibility = Visibility.PUBLIC,
     ) -> TextItem | PicItem | LinkItem:
         """
-        Insert new item. Code must be pre-resolved.
+        Insert new item. Code determined here with resolve_code.
         Raises CodeCollisionError if code already exists (application bug).
         """
         ...
@@ -398,12 +397,10 @@ class IngestOrchestrator:
         Full pipeline:
         1. IngestService.build_plan() → WritePlan
         2. Repo.get_by_full_hash() → dedupe check
-        3. Repo.resolve_code() → collision handling
+        3. Repo.insert() → resolve code and write metadata
         4. Storage.put() → write bytes (skip for LinkItem)
-        5. Repo.insert() → write metadata
-        6. Return PersistResult
-
-        On DB failure after storage write, calls Storage.delete() for rollback.
+        5. Return PersistResult
+        On Storage failure after DB write, calls Repo.delete() for rollback.
         """
         ...
 ```

--- a/doc/design/patterns.md
+++ b/doc/design/patterns.md
@@ -141,14 +141,13 @@ class IngestOrchestrator:
         existing = self._repo.get_by_full_hash(plan.hash_full)
         if existing:
             return PersistResult(existing, created=False)
-        
-        code = self._repo.resolve_code(plan.hash_full, plan.code_min_len)
-        self._storage.put(code=code, ...)
+
         try:
-            item = self._repo.insert(plan, code, ...)
+            item = self._repo.insert(plan, ...)
         except:
-            self._storage.delete(code=code, ...)
+            self._repo.delete(code=item.code, ...)
             raise
+        self._storage.put(code=code, ...)
         return PersistResult(item, created=True)
 ```
 

--- a/doc/design/v1.md
+++ b/doc/design/v1.md
@@ -50,14 +50,14 @@ Aliases provide mutability without mutating Items.
   - optional `message`
   - optional `author_user_id`
 
-**Routes**
+#### Alias Routes
 
 - `GET /a/{name}` → redirects to current `/{code}/info`
 - `GET /a/{name}/raw` → raw of current head
 - `GET /a/{name}/history` → revisions list
 - Optional pinning: `GET /a/{name}/v/{code}` → view a specific revision
 
-**Rules**
+#### Alias Rules
 
 - Updating an alias creates a new Item and advances `head_code`.
 - Old codes remain valid forever.
@@ -66,13 +66,13 @@ Aliases provide mutability without mutating Items.
 
 Add an editor for text-based content.
 
-**UX**
+#### Alias UX
 
 - `GET /a/{name}/edit` for alias-backed editable documents
 - `GET /{code}/fork` (optional) to create alias from an immutable item
 - Autosave optional; manual save is acceptable for v1.0
 
-**Save behavior**
+#### Alias Save behavior
 
 - Editor POST creates a new TextItem (new immutable code).
 - Alias is advanced to point to the new code.
@@ -123,7 +123,7 @@ Storage becomes pluggable:
 - Origin can be filesystem or object store.
 - Local filesystem cache uses LRU eviction.
 
-**Hard rules**
+#### Object store origin - Hard rules**
 
 - Content identity remains bytes-hash based.
 - Cache never changes bytes, only mirrors.
@@ -132,7 +132,7 @@ Storage becomes pluggable:
 
 Introduce metadata cache to reduce DB queries.
 
-**Pattern**
+#### Metadata caching pattern**
 
 - `CachedRepository` wraps `Repository`:
   - read-through on `get_by_code`
@@ -196,7 +196,9 @@ class AliasRepository(Protocol):
     def resolve_head_code(self, name: str) -> Optional[str]:
         ...
 
-    def set_head_code(self, name: str, new_code: str, *, message: Optional[str] = None) -> AliasMeta:
+    def set_head_code(
+        self, name: str, new_code: str, *, message: Optional[str] = None
+    ) -> AliasMeta:
         '''Appends revision and advances head atomically.'''
         ...
 
@@ -312,7 +314,8 @@ requiring a rewrite.
 
 ### 7.8 Advanced content classification
 
-MVP classification uses simple priority: explicit request > MIME hint > magic bytes > filename extension.
+MVP classification uses simple priority:
+explicit request > MIME hint > magic bytes > filename extension.
 
 Future enhancements:
 
@@ -333,13 +336,17 @@ Future enhancements:
   - User correction before submission
   - Feedback loop for improving heuristics
 
-Classification remains deterministic for identical inputs. User corrections do not alter inference logic — they override it per-upload.
+Classification remains deterministic for identical inputs.
+User corrections do not alter inference logic — they override it per-upload.
 
 ## 8. Tagging and Discovery (v1.0)
 
-Tagging is introduced as a **discovery and organization mechanism**, not an identity or access mechanism.
+Tagging is introduced as a **discovery and organization mechanism**,
+not an identity or access mechanism.
 
-Tags are intentionally designed to be flexible, mutable metadata that support browsing and filtering without affecting content identity or stability.
+Tags are intentionally designed to be flexible,
+mutable metadata that support browsing and filtering without
+affecting content identity or stability.
 
 ---
 
@@ -359,7 +366,7 @@ Tags are intentionally designed to be flexible, mutable metadata that support br
 
 In v1.0, tags are primarily associated with **aliases**, not immutable items.
 
-**Rationale**
+#### Alias-first tagging rationale
 
 - Aliases represent the *current, user-facing version* of content.
 - Aliases are mutable by design and can move across versions.
@@ -371,7 +378,7 @@ In v1.0, tags are primarily associated with **aliases**, not immutable items.
 This aligns tags with how users typically think about organization:
 > “How do I want to group or find this document right now?”
 
-**Implication**
+#### Alias-first tagging - Implication
 
 - When an alias advances to a new item version, its tags continue to apply.
 - Historical immutable items remain untagged unless explicitly annotated.
@@ -380,7 +387,8 @@ This aligns tags with how users typically think about organization:
 
 ### 8.3 Tagging immutable items (future-compatible)
 
-The model is intentionally designed so tags **may also be associated with immutable items** in the future.
+The model is intentionally designed so
+tags **may also be associated with immutable items** in the future.
 
 Item-level tagging is useful for:
 
@@ -425,14 +433,16 @@ The result set may change over time as:
 
 - Content with no tags has **no tag records** (null / absence).
 - No automatic or synthetic `untagged` tag is created.
-- Views for untagged content, if desired, are implemented as explicit filters or UI affordances.
+- Views for untagged content, if desired,
+  - are implemented as explicit filters or UI affordances.
 
 ---
 
 ### 8.6 Permissions
 
 - Only authorized users may add or remove tags.
-- Public users may view tags and tag-based discovery results, subject to content visibility rules.
+- Public users may view tags and tag-based discovery results
+  - subject to content visibility rules.
 
 ---
 
@@ -444,7 +454,9 @@ The result set may change over time as:
 
 ### 8.8 Example data model (illustrative)
 
-The following tables illustrate one possible schema that supports alias-first tagging while remaining compatible with future item-level tagging.
+The following tables illustrate one possible schema that
+supports alias-first tagging while remaining compatible with
+future item-level tagging.
 
 These are **examples**, not hard requirements.
 
@@ -465,7 +477,7 @@ Associates a tag with an alias (v1.0 default).
 - `created_at`
 - optional `created_by_user_id`
 
-**Properties**
+##### AliasTag Properties
 
 - Many-to-many relationship.
 - Tags persist across alias revisions.
@@ -481,7 +493,7 @@ Associates a tag with a specific immutable item.
 - optional `created_by_user_id`
 - optional `reason` (e.g. moderation, classification)
 
-**Properties**
+##### ItemTag Properties
 
 - Tags apply only to that specific immutable version.
 - Tags do not propagate when an alias advances.
@@ -495,4 +507,58 @@ Associates a tag with a specific immutable item.
 - Faceted tag counts are derived dynamically from the result set.
 - No tag table participates in hashing, identity, or code generation.
 
-This separation allows the system to support both **organizational tagging** and **historical annotation** without conflating their semantics.
+This separation allows the system to
+support both **organizational tagging** and **historical annotation** without
+conflating their semantics.
+
+### Future: Repository Architecture
+
+The current SQLite implementation lives in a single module (`repo/sqlite.py`). As the system grows, consider this structure:
+
+#### Entity-based split
+
+```
+repo/
+├── __init__.py          # Re-exports public API
+├── errors.py            # Shared exceptions
+├── schema.sql           # Unified schema (FK relationships)
+├── base.py              # init_db(), shared utilities
+├── items.py             # ItemRepository (items + subtypes)
+├── users.py             # UserRepository (future)
+├── tags.py              # TagRepository (future)
+```
+
+Each repo owns its tables and row mappers. Connection injected for testability.
+
+#### Multi-database support
+
+When adding Postgres support:
+
+```
+repo/
+├── protocol.py          # ItemRepository Protocol (abstract interface)
+├── errors.py            # Shared exceptions
+├── sqlite/
+│   ├── schema.sql
+│   ├── items.py         # SqliteItemRepository
+│   └── ...
+├── postgres/
+│   ├── schema.sql
+│   ├── items.py         # PostgresItemRepository
+│   └── ...
+```
+
+**What stays the same:**
+
+- Row mappers (dict → domain model)
+- Error types
+- Method signatures
+- Most queries (named params work in both)
+
+**What differs:**
+
+- Connection handling (sqlite3 vs asyncpg)
+- Schema syntax (INTEGER PRIMARY KEY vs SERIAL)
+- Async patterns for Postgres
+
+Factory function selects implementation based on config. Orchestrator depends on Protocol, concrete impl injected at startup.

--- a/doc/module/repo.md
+++ b/doc/module/repo.md
@@ -111,20 +111,18 @@ class SqliteRepository:
         """
         ...
 
-    def insert(
+  def insert(
         self,
         plan: WritePlan,
-        code: str,
         *,
         uid: int = 0,
         perm: Visibility = Visibility.PUBLIC,
     ) -> TextItem | PicItem | LinkItem:
         """
         Insert new item and subtype record.
-        Code must be pre-resolved via resolve_code().
-        
+        Resolves code internally from plan.hash_full and plan.code_min_len.
         Raises:
-            CodeCollisionError: If code already exists (application bug).
+            CodeCollisionError: If resolved code collides (indicates bug).
         """
         ...
 ```

--- a/doc/module/service.md
+++ b/doc/module/service.md
@@ -139,19 +139,16 @@ class IngestOrchestrator:
     ) -> PersistResult: ...
 ```
 
-**Pipeline:**
+#### IngestOrchestrator - Pipeline
 
 1. `IngestService.build_plan()` → WritePlan
 2. `Repo.get_by_full_hash()` → dedupe check, return early if exists
-3. `Repo.resolve_code()` → find unique code prefix
-4. `Storage.put()` → write bytes (skip for LinkItem)
-5. `Repo.insert()` → write metadata
-6. On insert failure → `Storage.delete()` for rollback
-7. Return `PersistResult(item, created)`
+3. `Storage.put()` → write bytes (skip for LinkItem)
+4. `Repo.insert()` → write metadata & `Repo.resolve_code()` to get unique code
+5. On insert failure → `Storage.delete()` for rollback
+6. Return `PersistResult(item, created)`
 
 #### IngestOrchestrator - Raises
 
 Re-raises exceptions from components.
 CodeCollisionError` on insert constraint violation (application bug).
-
-See doc/design/mvp.md §5.5 for design rationale.

--- a/src/depo/repo/errors.py
+++ b/src/depo/repo/errors.py
@@ -1,0 +1,19 @@
+# src/depo/repo/errors.py
+"""
+Repository-specific exceptions.
+Author: Marcus Grant
+Date: 2026-01-30
+License: Apache-2.0
+"""
+
+
+class RepoError(Exception):
+    """Base class for repository errors."""
+
+
+class CodeCollisionError(RepoError):
+    """Insert attempted with duplicate code. Indicates application bug."""
+
+    def __init__(self, code: str):
+        self.code = code
+        super().__init__(f"Code collision: {code}")

--- a/src/depo/repo/sqlite.py
+++ b/src/depo/repo/sqlite.py
@@ -11,6 +11,8 @@ from importlib import resources
 
 from depo.model.enums import ContentFormat, ItemKind, Visibility
 from depo.model.item import LinkItem, PicItem, TextItem
+from depo.model.write_plan import WritePlan
+from depo.repo.errors import CodeCollisionError
 
 
 def init_db(conn: sqlite3.Connection) -> None:
@@ -209,3 +211,96 @@ class SqliteRepository:
             if candidate not in existing:  # Check if in existing codes
                 return candidate  # If not, this is our new unique code
         return hash_full  # Fallback to full hash as code (extremely unlikely)
+
+    def insert(
+        self,
+        plan: WritePlan,
+        *,
+        uid: int = 0,
+        perm: Visibility = Visibility.PUBLIC,
+    ) -> TextItem | PicItem | LinkItem:
+        """
+        Insert new item and subtype record.
+
+        Resolves code internally from plan.hash_full and plan.code_min_len.
+
+        Args:
+            plan: WritePlan from ingest service.
+            uid: User ID (default 0 until auth layer).
+            perm: Visibility (default PUBLIC).
+
+        Returns:
+            Newly created item.
+
+        Raises:
+            CodeCollisionError: If resolved code collides (indicates bug).
+        """
+        # First resolve code using write_plan & create Items
+        code = self.resolve_code(plan.hash_full, plan.code_min_len)
+
+        # Prepare the deserialized base Item to return
+        base_item = {
+            "code": code,
+            "hash_full": plan.hash_full,
+            "kind": plan.kind,
+            "size_b": plan.size_b,
+            "uid": uid,
+            "perm": perm,
+            "upload_at": plan.upload_at,
+            "origin_at": plan.origin_at,
+        }
+
+        # Setup two insertion queries to be handled in one transaction
+        with self._conn:
+            # First write the common base item table
+            try:
+                self._conn.execute(
+                    "INSERT INTO items "
+                    "(hash_full, code, kind, size_b, uid, upload_at, origin_at, perm) "
+                    "VALUES (:hash_full, :code, :kind, :size_b, :uid, :upload_at, "
+                    ":origin_at, :perm)",
+                    base_item,
+                )
+            except sqlite3.IntegrityError as e:
+                if "UNIQUE" in e.args[0]:
+                    raise CodeCollisionError(f"Code collision on insert: {code}") from e
+
+            # Next handle the subtype table insertion based on ItemKind
+            if plan.kind == ItemKind.TEXT:
+                assert plan.format is not None  # Bug in the ingest pipeline
+                self._conn.execute(
+                    "INSERT INTO text_items (hash_full, format) "
+                    "VALUES (:hash_full, :format)",
+                    {"hash_full": plan.hash_full, "format": plan.format},
+                )
+                return TextItem(**base_item, format=plan.format)
+            elif plan.kind == ItemKind.PICTURE:
+                # Check for optional value bug in the ingest pipeline
+                assert plan.format is not None
+                assert plan.width is not None
+                assert plan.height is not None
+                self._conn.execute(
+                    "INSERT INTO pic_items (hash_full, format, width, height) "
+                    "VALUES (:hash_full, :format, :width, :height)",
+                    {
+                        "hash_full": plan.hash_full,
+                        "format": plan.format,
+                        "width": plan.width,
+                        "height": plan.height,
+                    },
+                )
+                return PicItem(
+                    **base_item,
+                    format=plan.format,
+                    width=plan.width,
+                    height=plan.height,
+                )
+            elif plan.kind == ItemKind.LINK:
+                assert plan.link_url is not None  # Bug in the ingest pipeline
+                self._conn.execute(
+                    "INSERT INTO link_items (hash_full, url) VALUES (:hash_full, :url)",
+                    {"hash_full": plan.hash_full, "url": plan.link_url},
+                )
+                return LinkItem(**base_item, url=plan.link_url)
+            else:
+                raise AssertionError(f"Unknown ItemKind: {plan.kind}")

--- a/tests/repo/test_errors.py
+++ b/tests/repo/test_errors.py
@@ -1,0 +1,25 @@
+# src/depo/repo/errors.py
+"""
+Tests for repository-specific exceptions.
+Author: Marcus Grant
+Date: 2026-01-30
+License: Apache-2.0
+"""
+
+from depo.repo.errors import CodeCollisionError, RepoError
+
+
+class TestCollisionError:
+    """Tests for CodeCollisionError exception."""
+
+    def test_attributes(self):
+        """Test that attributes are set correctly."""
+        error = CodeCollisionError("DUPLICATE_CODE")
+        assert error.code == "DUPLICATE_CODE"
+
+    def test_inheritance(self):
+        """Test that CodeCollisionError inherits from RepoError."""
+        assert isinstance(CodeCollisionError("DUPLICATE_CODE"), RepoError)
+
+    # stores code attribute correctly
+    # inherits from RepoError


### PR DESCRIPTION
## Summary

Implement write operations for SQLite repository: code resolution and item insertion.

## Changes

- Add `resolve_code()` -
  finds shortest unique code prefix, single query
- Add `CodeCollisionError` and `RepoError` base class
- Add `insert()` - resolves code internally,
  inserts base + subtype atomically
- Add test helpers `_insert_{text,pic,link}_item` for cleaner repo tests

## Design decisions

- `insert()` resolves code internally (safer API, no caller footgun)
- `Orchestrator` flow updated: DB first, storage second, rollback via `Repo.delete()`
- Future repo architecture documented in v1.md (entity split, Postgres support)

## Doc updates

Updated insert signature and orchestrator flow in mvp.md, patterns.md, service.md, repo.md
Added repository architecture plan to v1.md
