### PR TITLE
Add storage layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ venv/
 
 # Runtime data (never commit)
 data/
-storage/
+/storage/
 uploads/
 
 # Logs

--- a/src/depo/storage/filesystem.py
+++ b/src/depo/storage/filesystem.py
@@ -40,7 +40,7 @@ class FilesystemStorage(StorageBackend):
         Returns:
             Path: {root}/{code}.{ext}
         """
-        raise NotImplementedError
+        return self._root / f"{code}.{extension_for_format(format)}"
 
     def put(
         self,
@@ -89,7 +89,7 @@ class FilesystemStorage(StorageBackend):
         Raises:
             FileNotFoundError: If payload doesn't exist.
         """
-        raise NotImplementedError
+        return self._path_for(code, format).open("rb")
 
     def delete(self, *, code: str, format: ContentFormat) -> None:
         """

--- a/src/depo/storage/filesystem.py
+++ b/src/depo/storage/filesystem.py
@@ -65,15 +65,12 @@ class FilesystemStorage(StorageBackend):
         # First validate source_* args
         if (source_bytes is None) == (source_path is None):
             raise ValueError("Exactly one of source_bytes or source_path required")
-        # create destination path using code & format
-        dest_path = self._root / f"{code}.{extension_for_format(format)}"
-
         if source_bytes is not None:
             # Write from bytes directly if source_bytes provided
-            dest_path.write_bytes(source_bytes)
-        if source_path is not None:
+            self._path_for(code, format).write_bytes(source_bytes)
+        elif source_path is not None:
             # Write from bytes stored in source_path
-            dest_path.write_bytes(source_path.read_bytes())
+            self._path_for(code, format).write_bytes(source_path.read_bytes())
 
     def open(self, *, code: str, format: ContentFormat) -> BinaryIO:
         """

--- a/src/depo/storage/filesystem.py
+++ b/src/depo/storage/filesystem.py
@@ -1,0 +1,91 @@
+# src/depo/storage/filesystem.py
+"""
+Local filesystem implementation of StorageBackend.
+
+Author: Marcus Grant
+Date: 2026-02-03
+License: Apache-2.0
+"""
+
+from pathlib import Path
+from typing import BinaryIO
+
+from depo.model.enums import ContentFormat
+from depo.storage.protocol import StorageBackend
+
+
+class FilesystemStorage(StorageBackend):
+    """Filesystem-backed storage for item payloads."""
+
+    def __init__(self, root: Path) -> None:
+        """
+        Initialize storage with root directory.
+
+        Args:
+            root: Base directory for all stored files.
+                  Created if it doesn't exist.
+        """
+        raise NotImplementedError
+
+    def _path_for(self, code: str, format: ContentFormat) -> Path:
+        """
+        Derive storage path for an item.
+
+        Args:
+            code: Short code identifier.
+            format: Content format (determines extension).
+
+        Returns:
+            Path: {root}/{code}.{ext}
+        """
+        raise NotImplementedError
+
+    def put(
+        self,
+        *,
+        code: str,
+        format: ContentFormat,
+        source_bytes: bytes | None = None,
+        source_path: Path | None = None,
+    ) -> None:
+        """
+        Write payload to storage.
+
+        Args:
+            code: Short code identifier.
+            format: Content format.
+            source_bytes: Raw bytes to write.
+            source_path: Path to file to copy.
+
+        Raises:
+            ValueError: If neither or both source arguments provided.
+        """
+        raise NotImplementedError
+
+    def open(self, *, code: str, format: ContentFormat) -> BinaryIO:
+        """
+        Open payload for reading.
+
+        Args:
+            code: Short code identifier.
+            format: Content format.
+
+        Returns:
+            Binary file handle. Caller must close.
+
+        Raises:
+            FileNotFoundError: If payload doesn't exist.
+        """
+        raise NotImplementedError
+
+    def delete(self, *, code: str, format: ContentFormat) -> None:
+        """
+        Remove payload from storage.
+
+        Idempotent—no error if missing.
+
+        Args:
+            code: Short code identifier.
+            format: Content format.
+        """
+        raise NotImplementedError

--- a/src/depo/storage/filesystem.py
+++ b/src/depo/storage/filesystem.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import BinaryIO
 
 from depo.model.enums import ContentFormat
+from depo.model.formats import extension_for_format
 from depo.storage.protocol import StorageBackend
 
 
@@ -61,7 +62,18 @@ class FilesystemStorage(StorageBackend):
         Raises:
             ValueError: If neither or both source arguments provided.
         """
-        raise NotImplementedError
+        # First validate source_* args
+        if (source_bytes is None) == (source_path is None):
+            raise ValueError("Exactly one of source_bytes or source_path required")
+        # create destination path using code & format
+        dest_path = self._root / f"{code}.{extension_for_format(format)}"
+
+        if source_bytes is not None:
+            # Write from bytes directly if source_bytes provided
+            dest_path.write_bytes(source_bytes)
+        if source_path is not None:
+            # Write from bytes stored in source_path
+            dest_path.write_bytes(source_path.read_bytes())
 
     def open(self, *, code: str, format: ContentFormat) -> BinaryIO:
         """

--- a/src/depo/storage/filesystem.py
+++ b/src/depo/storage/filesystem.py
@@ -25,7 +25,8 @@ class FilesystemStorage(StorageBackend):
             root: Base directory for all stored files.
                   Created if it doesn't exist.
         """
-        raise NotImplementedError
+        self._root = root
+        self._root.mkdir(parents=True, exist_ok=True)
 
     def _path_for(self, code: str, format: ContentFormat) -> Path:
         """

--- a/src/depo/storage/filesystem.py
+++ b/src/depo/storage/filesystem.py
@@ -101,4 +101,4 @@ class FilesystemStorage(StorageBackend):
             code: Short code identifier.
             format: Content format.
         """
-        raise NotImplementedError
+        self._path_for(code, format).unlink(missing_ok=True)

--- a/src/depo/storage/protocol.py
+++ b/src/depo/storage/protocol.py
@@ -1,0 +1,71 @@
+# src/depo/storage/protocol.py
+"""
+Storage backend protocol definition.
+
+Author: Marcus Grant
+Date: 2026-02-03
+License: Apache-2.0
+"""
+
+from pathlib import Path
+from typing import BinaryIO, Protocol
+
+from depo.model.enums import ContentFormat
+
+
+class StorageBackend(Protocol):
+    """Protocol for payload storage backends."""
+
+    def put(
+        self,
+        *,
+        code: str,
+        format: ContentFormat,
+        source_bytes: bytes | None = None,
+        source_path: Path | None = None,
+    ) -> None:
+        """
+        Write payload to storage.
+
+        Exactly one of source_bytes or source_path must be provided.
+
+        Args:
+            code: Short code identifier for the item.
+            format: Content format (determines file extension).
+            source_bytes: Raw bytes to write.
+            source_path: Path to file to copy.
+
+        Raises:
+            ValueError: If neither or both source arguments provided.
+        """
+        ...
+
+    def open(self, *, code: str, format: ContentFormat) -> BinaryIO:
+        """
+        Open payload for reading.
+
+        Caller responsible for closing the handle.
+
+        Args:
+            code: Short code identifier for the item.
+            format: Content format (determines file extension).
+
+        Returns:
+            Binary file handle for reading.
+
+        Raises:
+            FileNotFoundError: If payload doesn't exist.
+        """
+        ...
+
+    def delete(self, *, code: str, format: ContentFormat) -> None:
+        """
+        Remove payload from storage.
+
+        Idempotent—no error if file doesn't exist.
+
+        Args:
+            code: Short code identifier for the item.
+            format: Content format (determines file extension).
+        """
+        ...

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ import pytest
 
 pytest_plugins = [
     "tests.fixtures.db",
+    "tests.fixtures.storage",
 ]
 
 

--- a/tests/fixtures/storage.py
+++ b/tests/fixtures/storage.py
@@ -12,12 +12,6 @@ from src.depo.storage.filesystem import FilesystemStorage
 
 
 @pytest.fixture
-def test_storage_root(tmp_path):
-    """Temporary directory for storage tests."""
-    return tmp_path / "storage"
-
-
-@pytest.fixture
-def test_storage(test_storage_root):
+def tmp_fs(tmp_path):
     """FilesystemStorage instance with temporary root."""
-    return FilesystemStorage(root=test_storage_root)
+    return FilesystemStorage(root=tmp_path / "depo-test")

--- a/tests/fixtures/storage.py
+++ b/tests/fixtures/storage.py
@@ -7,7 +7,6 @@ License: Apache-2.0
 """
 
 import pytest
-
 from src.depo.storage.filesystem import FilesystemStorage
 
 

--- a/tests/fixtures/storage.py
+++ b/tests/fixtures/storage.py
@@ -8,16 +8,16 @@ License: Apache-2.0
 
 import pytest
 
+from src.depo.storage.filesystem import FilesystemStorage
+
 
 @pytest.fixture
-def test_storage_root():
+def test_storage_root(tmp_path):
     """Temporary directory for storage tests."""
-    # TODO: Implement in PR 4 (storage layer)
-    raise NotImplementedError("test_storage_root fixture not yet implemented")
+    return tmp_path / "storage"
 
 
 @pytest.fixture
-def test_storage():
+def test_storage(test_storage_root):
     """FilesystemStorage instance with temporary root."""
-    # TODO: Implement in PR 4 (storage layer)
-    raise NotImplementedError("test_storage fixture not yet implemented")
+    return FilesystemStorage(root=test_storage_root)

--- a/tests/storage/test_filesystem.py
+++ b/tests/storage/test_filesystem.py
@@ -1,0 +1,13 @@
+# tests/storage/test_filesystem.py
+"""
+Tests for storage/filesystem.py FilesystemStorage.
+
+Author: Marcus Grant
+Date: 2026-02-03
+License: Apache-2.0
+"""
+
+import pytest
+
+from depo.model.enums import ContentFormat
+from depo.storage.filesystem import FilesystemStorage

--- a/tests/storage/test_filesystem.py
+++ b/tests/storage/test_filesystem.py
@@ -10,6 +10,7 @@ License: Apache-2.0
 import pytest
 
 from depo.model.enums import ContentFormat
+from depo.model.formats import extension_for_format
 from depo.storage.filesystem import FilesystemStorage
 
 
@@ -36,5 +37,54 @@ class TestFilesystemStorageInit:
         """Test that the root path is stored correctly."""
         storage = FilesystemStorage(root=tmp_path / "depo")
         assert storage._root == tmp_path / "depo"
+
+
+class TestFilesystemStoragePut:
+    """Tests FilesystemStorage.put()."""
+
+    def test_writes_source_bytes_to_correct_path(self, tmp_fs):
+        """Writes source_bytes to {root}/{code}.{ext} & ext from extension_for_format"""
+        # Assemble shortened format references
+        cf_txt, cf_tif = ContentFormat.PLAINTEXT, ContentFormat.TIFF
+
+        # Act on test bytes 0x00ff00 is an edge case for empty file headers
+        # TIFF proves extension_for_format is used (special case TIFF -> tif)
+        tmp_fs.put(code="ABC123", format=cf_txt, source_bytes=b"hello")
+        tmp_fs.put(code="XYZ789", format=cf_tif, source_bytes=b"\x00\xff\x00")
+
+        # Assert test bytes are readable from expected paths
+        path_txt = tmp_fs._root / f"ABC123.{extension_for_format(cf_txt)}"
+        path_tif = tmp_fs._root / f"XYZ789.{extension_for_format(cf_tif)}"
+        assert path_txt.read_bytes() == b"hello"
+        assert path_tif.read_bytes() == b"\x00\xff\x00"
+
+    def test_writes_source_path_to_correct_path(self, tmp_fs):
+        """Writes source_path contents to {root}/{code}.{ext} uses ext.._format"""
+        # Assemble temporary file paths with test data
+        tmp_jpg, tmp_tif = tmp_fs._root / "jpeg.tmp", tmp_fs._root / "tif.tmp"
+        tmp_jpg.write_bytes(b"hello")
+        tmp_tif.write_bytes(b"\x00\xff\x00")
+        cf_jpg, cf_tif = ContentFormat.JPEG, ContentFormat.TIFF  # shorten references
+
+        # Act with temp file paths
+        tmp_fs.put(code="jpg12345", format=cf_jpg, source_path=tmp_jpg)
+        tmp_fs.put(code="tifmpqrs", format=cf_tif, source_path=tmp_tif)
+
+        # Assert same data in expected paths made by extension_for_format
+        path_jpg = tmp_fs._root / f"jpg12345.{extension_for_format(cf_jpg)}"
+        path_tif = tmp_fs._root / f"tifmpqrs.{extension_for_format(cf_tif)}"
+        assert path_jpg.read_bytes() == b"hello"
+        assert path_tif.read_bytes() == b"\x00\xff\x00"
+
+    def test_raises_for_none_or_both_source_args(self, tmp_fs):
+        """Raises for both source_* args being both None or both valid values"""
+        err = r"(?i)one of.*source"
+        base_kwargs = {"code": "f00bar", "format": ContentFormat.PNG}
+        with pytest.raises(ValueError, match=err):
+            # Raise when both source_* args are None
+            tmp_fs.put(**base_kwargs)
+        with pytest.raises(ValueError, match=err):
+            # Raise when both source_* args are valid values
+            tmp_fs.put(**base_kwargs, source_bytes=b"hi", source_path=tmp_fs._root)
 
 

--- a/tests/storage/test_filesystem.py
+++ b/tests/storage/test_filesystem.py
@@ -108,3 +108,23 @@ class TestFilesystemStorageOpen:
             tmp_fs.open(code="N0TEX1ST", format=ContentFormat.PNG)
 
 
+class TestFilesystemStorageDelete:
+    """Tests FilesystemStorage.delete()."""
+
+    def test_removes_existing_file(self, tmp_fs):
+        """Removes existing file"""
+        # Assemble existing test file with code and format
+        code, fmt, data = "F1LEX1ST", ContentFormat.PLAINTEXT, b"Hello, World!"
+        tmp_fs.put(code=code, format=fmt, source_bytes=data)
+
+        # Act by using delete() on existing test file
+        tmp_fs.delete(code=code, format=fmt)
+
+        # Assert the file no longer exists by using .open to raise FileNotFoundError
+        with pytest.raises(FileNotFoundError):
+            tmp_fs.open(code=code, format=fmt)
+
+    def test_no_error_for_missing_file(self, tmp_fs):
+        """No error when attempting to delete non-existing file"""
+        # Act by delete() on non-existing file - asserts by not raising
+        tmp_fs.delete(code="N0TEX1ST", format=ContentFormat.PNG)

--- a/tests/storage/test_filesystem.py
+++ b/tests/storage/test_filesystem.py
@@ -10,7 +10,6 @@ License: Apache-2.0
 import pytest
 
 from depo.model.enums import ContentFormat
-from depo.model.formats import extension_for_format
 from depo.storage.filesystem import FilesystemStorage
 
 
@@ -43,49 +42,41 @@ class TestFilesystemStoragePut:
     """Tests FilesystemStorage.put()."""
 
     def test_writes_source_bytes_to_correct_path(self, tmp_fs):
-        """Writes source_bytes to {root}/{code}.{ext} & ext from extension_for_format"""
-        # Assemble shortened format references
-        cf_txt, cf_tif = ContentFormat.PLAINTEXT, ContentFormat.TIFF
-
-        # Act on test bytes 0x00ff00 is an edge case for empty file headers
-        # TIFF proves extension_for_format is used (special case TIFF -> tif)
-        tmp_fs.put(code="ABC123", format=cf_txt, source_bytes=b"hello")
-        tmp_fs.put(code="XYZ789", format=cf_tif, source_bytes=b"\x00\xff\x00")
-
-        # Assert test bytes are readable from expected paths
-        path_txt = tmp_fs._root / f"ABC123.{extension_for_format(cf_txt)}"
-        path_tif = tmp_fs._root / f"XYZ789.{extension_for_format(cf_tif)}"
-        assert path_txt.read_bytes() == b"hello"
-        assert path_tif.read_bytes() == b"\x00\xff\x00"
+        """Writes source_bytes to {root}/{code}.{ext}"""
+        tmp_fs.put(code="ABC123", format=ContentFormat.PLAINTEXT, source_bytes=b"hello")
+        tmp_fs.put(
+            code="XYZ789", format=ContentFormat.TIFF, source_bytes=b"\x00\xff\x00"
+        )
+        # TIFF -> tif proves extension_for_format is used
+        assert (tmp_fs._root / "ABC123.txt").read_bytes() == b"hello"
+        assert (tmp_fs._root / "XYZ789.tif").read_bytes() == b"\x00\xff\x00"
 
     def test_writes_source_path_to_correct_path(self, tmp_fs):
-        """Writes source_path contents to {root}/{code}.{ext} uses ext.._format"""
-        # Assemble temporary file paths with test data
-        tmp_jpg, tmp_tif = tmp_fs._root / "jpeg.tmp", tmp_fs._root / "tif.tmp"
+        """Writes source_path contents to {root}/{code}.{ext}"""
+        # Assemble temporary files with test data
+        tmp_jpg = tmp_fs._root / "input.jpg"
+        tmp_tif = tmp_fs._root / "input.tif"
         tmp_jpg.write_bytes(b"hello")
         tmp_tif.write_bytes(b"\x00\xff\x00")
-        cf_jpg, cf_tif = ContentFormat.JPEG, ContentFormat.TIFF  # shorten references
-
-        # Act with temp file paths
-        tmp_fs.put(code="jpg12345", format=cf_jpg, source_path=tmp_jpg)
-        tmp_fs.put(code="tifmpqrs", format=cf_tif, source_path=tmp_tif)
-
-        # Assert same data in expected paths made by extension_for_format
-        path_jpg = tmp_fs._root / f"jpg12345.{extension_for_format(cf_jpg)}"
-        path_tif = tmp_fs._root / f"tifmpqrs.{extension_for_format(cf_tif)}"
-        assert path_jpg.read_bytes() == b"hello"
-        assert path_tif.read_bytes() == b"\x00\xff\x00"
+        # Act
+        tmp_fs.put(code="jpg12345", format=ContentFormat.JPEG, source_path=tmp_jpg)
+        tmp_fs.put(code="tifmpqrs", format=ContentFormat.TIFF, source_path=tmp_tif)
+        # Assert
+        assert (tmp_fs._root / "jpg12345.jpg").read_bytes() == b"hello"
+        assert (tmp_fs._root / "tifmpqrs.tif").read_bytes() == b"\x00\xff\x00"
 
     def test_raises_for_none_or_both_source_args(self, tmp_fs):
         """Raises for both source_* args being both None or both valid values"""
         err = r"(?i)one of.*source"
-        base_kwargs = {"code": "f00bar", "format": ContentFormat.PNG}
         with pytest.raises(ValueError, match=err):
-            # Raise when both source_* args are None
-            tmp_fs.put(**base_kwargs)
+            tmp_fs.put(code="f00bar", format=ContentFormat.PNG)
         with pytest.raises(ValueError, match=err):
-            # Raise when both source_* args are valid values
-            tmp_fs.put(**base_kwargs, source_bytes=b"hi", source_path=tmp_fs._root)
+            tmp_fs.put(
+                code="f00bar",
+                format=ContentFormat.PNG,
+                source_bytes=b"hi",
+                source_path=tmp_fs._root,
+            )
 
 
 class TestFilesystemStorageOpen:

--- a/tests/storage/test_filesystem.py
+++ b/tests/storage/test_filesystem.py
@@ -11,3 +11,30 @@ import pytest
 
 from depo.model.enums import ContentFormat
 from depo.storage.filesystem import FilesystemStorage
+
+
+class TestFilesystemStorageInit:
+    """Tests FilesystemStorage constructor."""
+
+    def test_creates_root_dir_if_missing(self, tmp_path):
+        """Test that the root directory is created if it doesn't exist."""
+        root = tmp_path / "depo"
+        assert not root.exists()
+        FilesystemStorage(root=root)
+        assert root.is_dir()
+
+    def test_accepts_existing_root_dir(self, tmp_path):
+        """Test that an existing directory is accepted as root."""
+        root = tmp_path / "depo"
+        root.mkdir()
+        assert root.is_dir()
+        storage = FilesystemStorage(root=root)
+        assert root.is_dir()
+        assert isinstance(storage, FilesystemStorage)
+
+    def test_stores_root_path(self, tmp_path):
+        """Test that the root path is stored correctly."""
+        storage = FilesystemStorage(root=tmp_path / "depo")
+        assert storage._root == tmp_path / "depo"
+
+

--- a/tests/storage/test_filesystem.py
+++ b/tests/storage/test_filesystem.py
@@ -88,3 +88,23 @@ class TestFilesystemStoragePut:
             tmp_fs.put(**base_kwargs, source_bytes=b"hi", source_path=tmp_fs._root)
 
 
+class TestFilesystemStorageOpen:
+    """Tests FilesystemStorage.open()."""
+
+    def test_file_handle_for_existing_file(self, tmp_fs):
+        """Returns file handle for existing file"""
+        # Assemble existing test file & expected inputs
+        code, fmt, data = "19F00BAR", ContentFormat.JSON, b"FooBar"
+        tmp_fs.put(code=code, format=fmt, source_bytes=data)
+
+        # Act by opening put test file
+        with tmp_fs.open(code=code, format=fmt) as f:
+            # Assert by comparing put data with opened
+            assert f.read() == data
+
+    def test_raises_for_no_file(self, tmp_fs):
+        """Raises FileNotFoundError for missing file"""
+        with pytest.raises(FileNotFoundError):
+            tmp_fs.open(code="N0TEX1ST", format=ContentFormat.PNG)
+
+


### PR DESCRIPTION
# Add storage layer

Implements `StorageBackend` protocol and
`FilesystemStorage` for local file persistence.

- `StorageBackend` protocol with:
  - `put()`
  - `open()`
  - `delete()`
- `FilesystemStorage` implementation of
  flat `{root}/{code}.{ext}` structure
- Idempotent delete for rollback support
- `tmp_fs` fixture for testing

