### PR TITLE
Ft: Ingest orchestration layer

### DIFF
--- a/doc/design/v1.md
+++ b/doc/design/v1.md
@@ -290,6 +290,16 @@ requiring a rewrite.
 - Object store as origin with local filesystem cache (LRU eviction).
 - Background garbage collection for unreferenced or purged payloads.
 - Storage backend remains replaceable and opaque to higher layers.
+- **Content/metadata separation:** Current design couples content identity
+  and per-upload metadata in the `items` table. Future split:
+  - `content` table: hash_full PK, format, size_b (immutable blob identity)
+  - `items`/aliases become metadata pointers to content (uid, perm, tags)
+  - Multiple aliases referencing same content achieves storage deduplication
+    while preserving per-user metadata
+  - This converges with the alias system (§2.1)—aliases *are* the per-user
+    metadata layer rather than a separate concept
+  - Subtype tables (text_items, pic_items, link_items) would FK to content,
+    not items
 
 ### 7.5 Metadata and access caching
 
@@ -514,6 +524,30 @@ conflating their semantics.
 ### Future: Repository Architecture
 
 The current SQLite implementation lives in a single module (`repo/sqlite.py`). As the system grows, consider this structure:
+
+#### Query construction abstraction
+
+Two options under consideration:
+
+**Option A — Query constants module:** Simple string constants per dialect.
+Minimal complexity, sufficient if query count stays small.
+
+**Option B — Query builder:** Method-chaining builder supporting
+SELECT, FROM, WHERE, IN, LIKE, INSERT INTO, JOIN.
+Enables dialect switching (SQLite `?` vs PostgreSQL `%s`).
+Higher upfront cost, pays off with PostgreSQL migration.
+
+Additionally, a **mapper module** to handle WritePlan → query params
+and row results → Item subtypes would centralize (de)serialization
+currently spread across SqliteRepository.
+
+#### Single-transaction dedupe
+
+Current dedupe uses `get_by_full_hash()` before `insert()` (two transactions).
+PostgreSQL supports `INSERT ... ON CONFLICT DO NOTHING RETURNING *` for
+single round-trip dedupe. SQLite equivalent is `INSERT OR IGNORE` with
+`changes()` check.
+Consider when optimizing write path.
 
 #### Entity-based split
 

--- a/doc/module/service.md
+++ b/doc/module/service.md
@@ -143,9 +143,9 @@ class IngestOrchestrator:
 
 1. `IngestService.build_plan()` → WritePlan
 2. `Repo.get_by_full_hash()` → dedupe check, return early if exists
-3. `Storage.put()` → write bytes (skip for LinkItem)
-4. `Repo.insert()` → write metadata & `Repo.resolve_code()` to get unique code
-5. On insert failure → `Storage.delete()` for rollback
+3. `Repo.insert()` → resolve code internally, write metadata
+4. `Storage.put()` → write bytes (skip for LinkItem)
+5. On storage failure → `Repo.delete()` for rollback
 6. Return `PersistResult(item, created)`
 
 #### IngestOrchestrator - Raises

--- a/doc/module/service.md
+++ b/doc/module/service.md
@@ -76,6 +76,7 @@ class IngestService:
         *,
         min_code_length: int = 8,
         max_size_bytes: int = 2**20,
+        max_url_len: int = 2048,
     ) -> None: ...
 
     def build_plan(
@@ -86,6 +87,7 @@ class IngestService:
         filename: str | None = None,
         declared_mime: str | None = None,
         requested_format: ContentFormat | None = None,
+        link_url: str | None = None,
     ) -> WritePlan: ...
 ```
 
@@ -94,9 +96,15 @@ class IngestService:
 1. Validate payload (exactly one of bytes/path)
 2. Validate size (non-empty, within limit)
 3. Hash content via `hash_full_b32`
-4. Classify via `classify()`
+4. Classify via `classify()` or Assemble early exit `WritePlan` if `LinkItem`
 5. Extract image metadata if `PICTURE` kind
 6. Assemble and return `WritePlan`
+
+>**NOTE:** The `payload_path` just gets re-routed to `payload_bytes`.
+>Deferring `payload_path` handling till streaming content to temp files implemented.
+>
+>**NOTE:** `link_url` is an explicit branch,
+>future inference from text payload as fallback.
 
 **Raises:** `ValueError` for validation or classification failures.
 
@@ -131,6 +139,7 @@ class IngestOrchestrator:
         *,
         payload_bytes: bytes | None = None,
         payload_path: Path | None = None,
+        link_url: str | None = None,
         filename: str | None = None,
         declared_mime: str | None = None,
         requested_format: ContentFormat | None = None,

--- a/src/depo/model/enums.py
+++ b/src/depo/model/enums.py
@@ -39,6 +39,7 @@ class PayloadKind(StrEnum):
 
     BYTES = "byte"
     FILE = "file"
+    NONE = "none"
 
 
 class ContentFormat(StrEnum):

--- a/src/depo/repo/schema.sql
+++ b/src/depo/repo/schema.sql
@@ -16,19 +16,19 @@ CREATE TABLE IF NOT EXISTS items (
 );
 
 CREATE TABLE IF NOT EXISTS text_items (
-    hash_full   TEXT PRIMARY KEY REFERENCES items(hash_full),
+    hash_full   TEXT PRIMARY KEY REFERENCES items(hash_full) ON DELETE CASCADE,
     format      TEXT NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS pic_items (
-    hash_full   TEXT PRIMARY KEY REFERENCES items(hash_full),
+    hash_full   TEXT PRIMARY KEY REFERENCES items(hash_full) ON DELETE CASCADE,
     format      TEXT NOT NULL,
     width       INTEGER NOT NULL,
     height      INTEGER NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS link_items (
-    hash_full   TEXT PRIMARY KEY REFERENCES items(hash_full),
+    hash_full   TEXT PRIMARY KEY REFERENCES items(hash_full) ON DELETE CASCADE,
     url         TEXT NOT NULL
 );
 

--- a/src/depo/repo/sqlite.py
+++ b/src/depo/repo/sqlite.py
@@ -304,3 +304,16 @@ class SqliteRepository:
                 return LinkItem(**base_item, url=plan.link_url)
             else:
                 raise AssertionError(f"Unknown ItemKind: {plan.kind}")
+
+    def delete(self, hash_full: str) -> None:
+        """Delete item by hash.
+
+        Subtype row cascades automatically via FK constraint.
+
+        Args:
+            hash_full: Full hash of item to delete.
+
+        Note:
+            No-op if item doesn't exist (idempotent for rollback).
+        """
+        self._conn.execute("DELETE FROM items WHERE hash_full = ?", (hash_full,))

--- a/src/depo/repo/sqlite.py
+++ b/src/depo/repo/sqlite.py
@@ -18,10 +18,10 @@ from depo.repo.errors import CodeCollisionError
 def init_db(conn: sqlite3.Connection) -> None:
     """
     Apply schema to connection. Idempotent.
-
     Args:
         conn: SQLite connection to initialize.
     """
+    conn.execute("PRAGMA foreign_keys = ON")
     schema = resources.files("depo.repo").joinpath("schema.sql").read_text()
     conn.executescript(schema)
 

--- a/src/depo/service/ingest.py
+++ b/src/depo/service/ingest.py
@@ -22,6 +22,7 @@ from depo.util.shortcode import hash_full_b32
 
 # TODO: Create config loader infrastructure and centralized defaults
 # TODO: Implement file streaming for classification, hashing and sizing
+# TODO: Change logic to stream payload to tmp file NOT saving to payload_bytes
 class IngestService:
     """Orchestrates the ingest pipeline."""
 
@@ -63,12 +64,13 @@ class IngestService:
             ValueError: If invalid size payload given
         """
         # Validate and resolve payload to bytes
+        data: bytes
         if (payload_bytes is None) == (payload_path is None):
             raise ValueError("Expected one of payload_bytes or payload_path.")
         if payload_bytes is not None:
             data = payload_bytes
             payload_kind = PayloadKind.BYTES
-        else:
+        else:  # TODO: This changes with temp file streaming
             assert payload_path is not None  # for type checker
             data = payload_path.read_bytes()
             payload_kind = PayloadKind.FILE
@@ -99,6 +101,7 @@ class IngestService:
         # Assemble write plan
         return WritePlan(
             payload_kind=payload_kind,
+            payload_bytes=data,  # TODO: This changes with temp file streaming
             size_b=size,
             code_min_len=self.min_code_length,
             hash_full=hash,

--- a/src/depo/service/ingest.py
+++ b/src/depo/service/ingest.py
@@ -27,7 +27,11 @@ class IngestService:
     """Orchestrates the ingest pipeline."""
 
     def __init__(
-        self, *, min_code_length: int = 8, max_size_bytes: int = 2**20
+        self,
+        *,
+        min_code_length: int = 8,
+        max_size_bytes: int = 2**20,
+        max_url_len: int = 2048,
     ) -> None:
         """Initialize with configuration.
 
@@ -37,6 +41,7 @@ class IngestService:
         """
         self.min_code_length = min_code_length
         self.max_size_bytes = max_size_bytes
+        self.max_url_len = max_url_len
 
     def build_plan(
         self,
@@ -46,6 +51,7 @@ class IngestService:
         filename: str | None = None,
         declared_mime: str | None = None,
         requested_format: ContentFormat | None = None,
+        link_url: str | None = None,
     ) -> WritePlan:
         """Build a WritePlan from upload data.
 
@@ -63,19 +69,49 @@ class IngestService:
             ValueError: If validation or classification fails.
             ValueError: If invalid size payload given
         """
-        # Validate and resolve payload to bytes
+        # Validate source data
+        provided_sources = sum(
+            [payload_bytes is not None, payload_path is not None, link_url is not None]
+        )
+        if provided_sources != 1:
+            raise ValueError("Expected one of payload_bytes, payload_path or link_url.")
+
+        # Shortcut process for link_url - no need to classify & different validation
+        # TODO: Refactor: Validation should be its own module
+        if link_url is not None:
+            # Validate size & encode str to utf-8 to normalize hashed data
+            link_bytes = link_url.encode("utf-8")
+            ll = len(link_bytes)
+            if ll <= 0:
+                raise ValueError("link_url string is empty")
+            if ll > self.max_url_len:
+                raise ValueError(f"Link url len {ll} exceeds limit {self.max_url_len}")
+            # Validate URI Format
+            if not link_url.startswith(("http://", "https://")):
+                raise ValueError("Link url must start with http:// or https://")
+
+            # Assemble & return WritePlan
+            return WritePlan(
+                hash_full=hash_full_b32(link_bytes),
+                code_min_len=self.min_code_length,
+                payload_kind=PayloadKind.NONE,
+                kind=ItemKind.LINK,
+                size_b=ll,
+                upload_at=int(time.time()),
+                link_url=link_url,
+            )  # From here, we are no longer dealing with link_url
+
+        # Determine PayloadKind and read data if needed
         data: bytes
-        if (payload_bytes is None) == (payload_path is None):
-            raise ValueError("Expected one of payload_bytes or payload_path.")
         if payload_bytes is not None:
             data = payload_bytes
             payload_kind = PayloadKind.BYTES
         else:  # TODO: This changes with temp file streaming
-            assert payload_path is not None  # for type checker
+            assert payload_path is not None  # for type checkers
             data = payload_path.read_bytes()
             payload_kind = PayloadKind.FILE
 
-        # Validate size
+        # Validate payload size
         size = len(data)
         if size > self.max_size_bytes:
             msg = f"Payload size {size} bytes exceeds limit {self.max_size_bytes}"
@@ -83,8 +119,7 @@ class IngestService:
         if size <= 0:
             raise ValueError("Payload is empty")
 
-        # Create shortcode from payload and classify it
-        hash = hash_full_b32(data)
+        # If here - We're only dealing with a payload, classify it
         content_class = classify(
             data,
             filename=filename,
@@ -98,16 +133,16 @@ class IngestService:
             img_info = get_image_info(data)
             width, height = img_info.width, img_info.height
 
-        # Assemble write plan
+        # Assemble final write plan
         return WritePlan(
-            payload_kind=payload_kind,
-            payload_bytes=data,  # TODO: This changes with temp file streaming
-            size_b=size,
+            hash_full=hash_full_b32(data),
             code_min_len=self.min_code_length,
-            hash_full=hash,
+            payload_kind=payload_kind,
+            size_b=size,
+            upload_at=int(time.time()),
+            payload_bytes=data,  # TODO: This changes with temp file streaming
             kind=content_class.kind,
             format=content_class.format,
-            upload_at=int(time.time()),
             width=width,
             height=height,
         )

--- a/src/depo/service/orchestrator.py
+++ b/src/depo/service/orchestrator.py
@@ -1,0 +1,28 @@
+# src/depo/service/orchestrator.py
+"""
+Ingest orchestration.
+
+Coordinates IngestService, Repository, and Storage for the full
+ingest pipeline. Single entry point for web layer.
+
+Author: Marcus Grant
+Date: 2026-02-03
+License: Apache-2.0
+"""
+
+from dataclasses import dataclass
+
+from depo.model.item import LinkItem, PicItem, TextItem
+
+
+@dataclass(frozen=True)
+class PersistResult:
+    """Result of ingest operation.
+
+    Attributes:
+        item: The persisted item (new or existing).
+        created: True if newly created, False if deduplicated.
+    """
+
+    item: LinkItem | PicItem | TextItem
+    created: bool

--- a/src/depo/service/orchestrator.py
+++ b/src/depo/service/orchestrator.py
@@ -13,6 +13,9 @@ License: Apache-2.0
 from dataclasses import dataclass
 
 from depo.model.item import LinkItem, PicItem, TextItem
+from depo.repo.sqlite import SqliteRepository
+from depo.service.ingest import IngestService
+from depo.storage.protocol import StorageBackend
 
 
 @dataclass(frozen=True)
@@ -26,3 +29,24 @@ class PersistResult:
 
     item: LinkItem | PicItem | TextItem
     created: bool
+
+
+class IngestOrchestrator:
+    """Coordinates ingest pipeline between service, repo, and storage."""
+
+    def __init__(
+        self,
+        ingest_service: IngestService,
+        repo: SqliteRepository,
+        store: StorageBackend,
+    ) -> None:
+        """Initialize with dependencies.
+
+        Args:
+            ingest_service: Service for building WritePlans.
+            repo: Repository for persistence.
+            storage: Backend for file storage.
+        """
+        self._service = ingest_service
+        self._repo = repo
+        self._store = store

--- a/src/depo/service/orchestrator.py
+++ b/src/depo/service/orchestrator.py
@@ -103,8 +103,12 @@ class IngestOrchestrator:
         # Save into StorageBackend if not a LinkItem
         # TODO: Implement payload_path temp file streaming
         if not isinstance(item, LinkItem):
-            code, format = item.code, item.format
-            self._store.put(code=code, format=format, source_bytes=payload_bytes)
+            code, fmt = item.code, item.format
+            try:  # Try storing as errors can occur in storage layer that needs rollback
+                self._store.put(code=code, format=fmt, source_bytes=payload_bytes)
+            except:
+                self._repo.delete(item.hash_full)
+                raise
 
         # Return PersistResult as result of IngestOrchestrator pipeline
         return PersistResult(item=item, created=True)

--- a/src/depo/service/orchestrator.py
+++ b/src/depo/service/orchestrator.py
@@ -11,7 +11,10 @@ License: Apache-2.0
 """
 
 from dataclasses import dataclass
+from pathlib import Path
 
+from depo.model.enums import Visibility
+from depo.model.formats import ContentFormat
 from depo.model.item import LinkItem, PicItem, TextItem
 from depo.repo.sqlite import SqliteRepository
 from depo.service.ingest import IngestService
@@ -50,3 +53,48 @@ class IngestOrchestrator:
         self._service = ingest_service
         self._repo = repo
         self._store = store
+
+    def ingest(
+        self,
+        *,
+        payload_bytes: bytes | None = None,
+        payload_path: Path | None = None,
+        filename: str | None = None,
+        declared_mime: str | None = None,
+        requested_format: ContentFormat | None = None,
+        uid: int = 0,
+        perm: Visibility = Visibility.PUBLIC,
+    ) -> PersistResult:
+        """Ingest content and persist to repo and storage.
+
+        Args:
+            payload_bytes: Content as in-memory bytes.
+            payload_path: Path to content on disk.
+            filename: Original filename hint.
+            declared_mime: MIME type from HTTP header.
+            requested_format: Explicit format requested by user.
+            uid: User ID.
+            perm: Visibility level.
+
+        Returns:
+            PersistResult with item and created flag.
+
+        Raises:
+            ValueError: If validation or classification fails.
+        """
+        plan = self._service.build_plan(
+            payload_bytes=payload_bytes,
+            payload_path=payload_path,
+            filename=filename,
+            declared_mime=declared_mime,
+            requested_format=requested_format,
+        )  # First build WritePlan with IngestService
+
+        # Insert into database with WritePlan
+        item = self._repo.insert(plan)
+
+        # Save into StorageBackend
+        self._store.put(code=item.code, format=item.format, source_bytes=payload_bytes)  # type: ignore
+
+        # Return PersistResult as result of IngestOrchestrator pipeline
+        return PersistResult(item=item, created=True)

--- a/src/depo/service/orchestrator.py
+++ b/src/depo/service/orchestrator.py
@@ -92,6 +92,11 @@ class IngestOrchestrator:
             requested_format=requested_format,
         )  # First build WritePlan with IngestService
 
+        # Exit early if dupe item already exists
+        if item := self._repo.get_by_full_hash(plan.hash_full):
+            # Return dupe item in result but with created=False
+            return PersistResult(item=item, created=False)
+
         # Insert into database with WritePlan
         item = self._repo.insert(plan)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import sqlite3
 import pytest
 
 pytest_plugins = [
+    "tests.fixtures",
     "tests.fixtures.db",
     "tests.fixtures.storage",
 ]

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -9,7 +9,6 @@ from depo.service.orchestrator import IngestOrchestrator
 from depo.storage.filesystem import FilesystemStorage
 
 from .db import test_db
-from .storage import tmp_fs
 
 # TODO: Uncomment as implemented
 # from .storage import test_storage, test_storage_root
@@ -32,6 +31,7 @@ def test_orchestrator_env(test_db, tmp_fs):
 
 __all__ = [
     "test_db",
+    "test_store",
     "test_orchestrator_env",
     # "test_storage",
     # "test_storage_root",

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,13 +1,38 @@
 # tests/fixtures/__init__.py
 """Re-exports for test fixtures."""
 
+import pytest
+
+from depo.repo.sqlite import SqliteRepository
+from depo.service.ingest import IngestService
+from depo.service.orchestrator import IngestOrchestrator
+from depo.storage.filesystem import FilesystemStorage
+
 from .db import test_db
+from .storage import tmp_fs
 
 # TODO: Uncomment as implemented
 # from .storage import test_storage, test_storage_root
 
+
+@pytest.fixture
+def test_store(tmp_path):
+    """FilesystemStorage instance with temporary root."""
+    return FilesystemStorage(root=tmp_path / "depo-test-store")
+
+
+@pytest.fixture
+def test_orchestrator_env(test_db, tmp_fs):
+    """Returns (orchestrator, repo, storage) tuple"""
+    service = IngestService()
+    repo = SqliteRepository(test_db)
+    orch = IngestOrchestrator(service, repo, tmp_fs)
+    return (orch, repo, tmp_fs)
+
+
 __all__ = [
     "test_db",
+    "test_orchestrator_env",
     # "test_storage",
     # "test_storage_root",
 ]

--- a/tests/fixtures/storage.py
+++ b/tests/fixtures/storage.py
@@ -13,4 +13,4 @@ from src.depo.storage.filesystem import FilesystemStorage
 @pytest.fixture
 def tmp_fs(tmp_path):
     """FilesystemStorage instance with temporary root."""
-    return FilesystemStorage(root=tmp_path / "depo-test")
+    return FilesystemStorage(root=tmp_path / "depo-test-store")

--- a/tests/model/test_enums.py
+++ b/tests/model/test_enums.py
@@ -70,9 +70,11 @@ class TestPayloadKind:
 
     def test_member_count(self):
         """Always 2 members for now"""
-        assert len(PayloadKind) == 2
+        assert len(PayloadKind) == 3
 
-    @pytest.mark.parametrize("key,val", [("BYTES", "byte"), ("FILE", "file")])
+    @pytest.mark.parametrize(
+        "key,val", [("BYTES", "byte"), ("FILE", "file"), ("NONE", "none")]
+    )
     def test_member_key_values(self, key, val):
         """Should have these expected member names"""
         member = PayloadKind[key]

--- a/tests/repo/test_sqlite.py
+++ b/tests/repo/test_sqlite.py
@@ -444,3 +444,46 @@ class TestInsert:
         )
         result = repo.insert(plan)
         assert result.code == "ABCD1234X"  # Extended to 9 chars, no collision
+
+
+class TestDelete:
+    """Tests for SqliteRepository.delete()."""
+
+    def test_delete_cascades_to_subtype(self, test_db):
+        """Deleting item removes row from items and correct subtype table."""
+        hash_suffix = "0123456789ABCDEFGHJKMNP"
+        _insert_text_item(test_db, hash_full=f"T{hash_suffix}", code="TXTC0DE1")
+        _insert_pic_item(test_db, hash_full=f"P{hash_suffix}", code="PICC0DE1")
+        _insert_link_item(test_db, hash_full=f"L{hash_suffix}", code="URLC0DE1")
+        repo = SqliteRepository(test_db)
+
+        def count(t):
+            return test_db.execute(f"SELECT COUNT(*) FROM {t}").fetchone()[0]
+
+        assert count("items") == 3
+        assert count("text_items") == 1
+        assert count("pic_items") == 1
+        assert count("link_items") == 1
+
+        repo.delete("T0123456789ABCDEFGHJKMNP")
+        assert count("items") == 2
+        assert count("text_items") == 0
+        assert count("pic_items") == 1
+        assert count("link_items") == 1
+
+        repo.delete("P0123456789ABCDEFGHJKMNP")
+        assert count("items") == 1
+        assert count("text_items") == 0
+        assert count("pic_items") == 0
+        assert count("link_items") == 1
+
+        repo.delete("L0123456789ABCDEFGHJKMNP")
+        assert count("items") == 0
+        assert count("text_items") == 0
+        assert count("pic_items") == 0
+        assert count("link_items") == 0
+
+    def test_delete_nonexistent_is_noop(self, test_db):
+        """Deleting nonexistent hash doesn't raise."""
+        repo = SqliteRepository(test_db)
+        repo.delete("DOESNOTEXIST12345678")

--- a/tests/repo/test_sqlite.py
+++ b/tests/repo/test_sqlite.py
@@ -183,6 +183,10 @@ class TestInitDb:
         row = conn.execute("SELECT * FROM items").fetchone()
         assert row is not None
 
+    def test_foreign_keys_enabled(self, test_db):
+        """FK constraints are enabled after init."""
+        assert test_db.execute("PRAGMA foreign_keys").fetchone()[0] == 1
+
 
 class TestRowMappers:
     """Tests for row mapper functions."""

--- a/tests/service/test_ingest.py
+++ b/tests/service/test_ingest.py
@@ -193,3 +193,24 @@ class TestIngestServiceAssembly:
             requested_format=ContentFormat.PLAINTEXT,
         )
         assert plan.code_min_len == 12
+
+    # TODO: These two payload tests need changing when PayloadKind.FILE is supported
+    def test_writeplan_has_payload_bytes_from_bytes(self):
+        """WritePlan.payload_bytes populated from payload_bytes input."""
+        data = b"hello world"
+        plan = IngestService().build_plan(
+            payload_bytes=data,
+            requested_format=ContentFormat.PLAINTEXT,
+        )
+        assert plan.payload_bytes == data
+
+    def test_writeplan_has_payload_bytes_from_path(self, tmp_path):
+        """WritePlan.payload_bytes populated from payload_path input."""
+        f = tmp_path / "test.txt"
+        data = b"hello world"
+        f.write_bytes(data)
+        plan = IngestService().build_plan(
+            payload_path=f,
+            requested_format=ContentFormat.PLAINTEXT,
+        )
+        assert plan.payload_bytes == data

--- a/tests/service/test_ingest.py
+++ b/tests/service/test_ingest.py
@@ -21,13 +21,19 @@ from depo.util.shortcode import hash_full_b32
 class TestIngestServiceInit:
     """Tests IngestService constructor"""
 
-    @pytest.mark.parametrize("min_len,max_size", [(2, 2**10), (4, 2**20), (8, 2**30)])
-    def test_accepts_valid_configs(self, min_len, max_size):
+    @pytest.mark.parametrize(
+        "min_len,max_size,max_url",
+        [(2, 2**10, 2048), (4, 2**20, 1024), (8, 2**30, 4096)],
+    )
+    def test_accepts_valid_configs(self, min_len, max_size, max_url):
         """Accepts min_code_length & max_size_bytes as config"""
-        result = IngestService(min_code_length=min_len, max_size_bytes=max_size)
+        result = IngestService(
+            min_code_length=min_len, max_size_bytes=max_size, max_url_len=max_url
+        )
         assert isinstance(result, IngestService)
         assert result.min_code_length == min_len
         assert result.max_size_bytes == max_size
+        assert result.max_url_len == max_url
 
 
 class TestIngestServiceValidation:
@@ -145,6 +151,46 @@ class TestIngestServiceImage:
         # Prefer the JPEG EXIF magic bytes since EXIF expected
         with pytest.raises(ValueError, match=r"(?i)(invalid|corrupt)"):
             IngestService().build_plan(payload_bytes=b"\xff\xd8\xff\xe1")
+
+
+class TestBuildPlanLinkUrl:
+    """Tests for build_plan() with link_url."""
+
+    def test_returns_plan_with_expected_fields(self):
+        """Returns expected WritePlan with correct field values for urls"""
+        # build_plan doesnt need payload_{bytes,path}, only link_url
+        plan = IngestService().build_plan(link_url="http://a.eu")
+        assert plan.kind == ItemKind.LINK
+        assert plan.link_url == "http://a.eu"
+        assert plan.hash_full == hash_full_b32(bytes("http://a.eu", encoding="utf-8"))
+        assert plan.payload_kind == PayloadKind.NONE
+
+    def test_raises_for_link_and_payload_args(self):
+        """Raises if link_url provided along with any or both payload args"""
+        match, byt, pth, url = r"(?i)one of.*payload", b"\xff", Path("/"), "http://a.eu"
+        with pytest.raises(ValueError, match=match):
+            IngestService().build_plan(link_url=url, payload_bytes=byt)
+        with pytest.raises(ValueError, match=match):
+            IngestService().build_plan(link_url=url, payload_path=pth)
+        with pytest.raises(ValueError, match=match):
+            IngestService().build_plan(
+                link_url=url, payload_bytes=byt, payload_path=pth
+            )
+
+    @pytest.mark.parametrize(
+        "url, match",
+        [
+            ("", r"(?i)(empty|zero)"),
+            ("a" * 2049, r"(?i)(max|big|exceed)"),
+            ("www.example.com", r"(?i)(schema|http)"),
+        ],
+    )
+    def test_raises_for_invalid_link(self, url, match):
+        """Raises if invalid link_url provided
+        Invalid: Empty, Too big, no HTTP(s) prefix
+        """
+        with pytest.raises(ValueError, match=match):
+            IngestService(max_url_len=2048).build_plan(link_url=url)
 
 
 class TestIngestServiceAssembly:

--- a/tests/service/test_orchestrator.py
+++ b/tests/service/test_orchestrator.py
@@ -1,0 +1,46 @@
+# tests/service/test_orchestrator.py
+"""
+Tests for orchestrator module.
+
+Author: Marcus Grant
+Date: 2026-02-03
+License: Apache-2.0
+"""
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+from tests.factories.models import make_link_item, make_pic_item, make_text_item
+from tests.helpers.assertions import assert_field
+
+from depo.model.item import LinkItem, PicItem, TextItem
+from depo.service.orchestrator import PersistResult
+
+
+class TestPersistResult:
+    """Tests for PersistResult DTO."""
+
+    @pytest.mark.parametrize(
+        ("name", "typ", "required", "default"),
+        [
+            ("item", LinkItem | PicItem | TextItem, True, None),
+            ("created", bool, True, None),
+        ],
+    )
+    def test_correct_fields(self, name, typ, required, default):
+        """Field properties (name, type, required, default value) are correct."""
+        assert_field(PersistResult, name, typ, required, default)
+
+    def test_frozen_dataclass(self):
+        """Is a frozen dataclass"""
+        obj = PersistResult(item=make_link_item(), created=True)
+        assert isinstance(obj, PersistResult)
+        with pytest.raises(FrozenInstanceError):
+            obj.created = False  # type: ignore
+
+    def test_accepts_all_item_kinds(self):
+        """Can be instantiated with any Item subtype."""
+        for factory in [make_text_item, make_pic_item, make_link_item]:
+            item = factory()
+            result = PersistResult(item=item, created=False)
+            assert result.item is item, f"Failed for {type(item).__name__}"

--- a/tests/service/test_orchestrator.py
+++ b/tests/service/test_orchestrator.py
@@ -14,7 +14,9 @@ from tests.factories.models import make_link_item, make_pic_item, make_text_item
 from tests.helpers.assertions import assert_field
 
 from depo.model.item import LinkItem, PicItem, TextItem
-from depo.service.orchestrator import PersistResult
+from depo.repo.sqlite import SqliteRepository
+from depo.service.ingest import IngestService
+from depo.service.orchestrator import IngestOrchestrator, PersistResult
 
 
 class TestPersistResult:
@@ -44,3 +46,15 @@ class TestPersistResult:
             item = factory()
             result = PersistResult(item=item, created=False)
             assert result.item is item, f"Failed for {type(item).__name__}"
+
+
+class TestIngestOrchestratorInit:
+    """Tests for IngestOrchestrator constructor."""
+
+    def test_stores_all_members(self, test_db, tmp_fs):
+        """Stores IngestOrchestrator expected members"""
+        service, repo = IngestService(), SqliteRepository(test_db)
+        orchestrator = IngestOrchestrator(service, repo, tmp_fs)
+        assert orchestrator._service == service
+        assert orchestrator._repo == repo
+        assert orchestrator._store == tmp_fs

--- a/tests/service/test_orchestrator.py
+++ b/tests/service/test_orchestrator.py
@@ -11,6 +11,7 @@ from dataclasses import FrozenInstanceError
 
 import pytest
 from tests.factories.models import make_link_item, make_pic_item, make_text_item
+from tests.factories.payloads import gen_image
 from tests.helpers.assertions import assert_field
 
 from depo.model.enums import ContentFormat
@@ -56,38 +57,54 @@ class TestIngestOrchestratorInit:
         """Stores IngestOrchestrator expected members"""
         service, repo = IngestService(), SqliteRepository(test_db)
         orchestrator = IngestOrchestrator(service, repo, tmp_fs)
-        assert orchestrator._service == service
-        assert orchestrator._repo == repo
-        assert orchestrator._store == tmp_fs
+        assert orchestrator._service is service
+        assert orchestrator._repo is repo
+        assert orchestrator._store is tmp_fs
 
 
 class TestIngestOrchestratorIngest:
     """Tests for IngestOrchestrator.ingest()."""
 
-    def test_happy_path(self, test_db, tmp_fs):
-        """Happy path returns
-        - PersistedResult.created=True
-        - item persisted in repo
-        - bytes written to storage"""
-        # Assemble orchestrator inputs and basic ingest args
+    def test_happy_path_text_item(self, test_orchestrator_env):
+        """TextItem happy path: created=True, item in repo, bytes in storage."""
+        orch, repo, store = test_orchestrator_env
         payload, fmt = b"Hello, World!", ContentFormat.PLAINTEXT
-        service, repo = IngestService(), SqliteRepository(test_db)
-        orchestrator = IngestOrchestrator(service, repo, tmp_fs)
 
-        # Act with ingest in happy path and collect PersistedResult & item fields
-        result = orchestrator.ingest(payload_bytes=payload, requested_format=fmt)
+        result = orch.ingest(payload_bytes=payload, requested_format=fmt)
         item, hash_full, code = result.item, result.item.hash_full, result.item.code
 
-        # Assert result.created == True, item in repo, content in store
         assert isinstance(result, PersistResult)
         assert result.created
         assert repo.get_by_full_hash(hash_full) == item
         assert isinstance(item, TextItem)
-        with tmp_fs.open(code=code, format=item.format) as f:
+        with store.open(code=code, format=item.format) as f:
             assert f.read() == payload
 
+    def test_happy_path_pic_item(self, test_orchestrator_env):
+        """PicItem happy path: created=True, item in repo, bytes in storage."""
+        orch, repo, storage = test_orchestrator_env
+        payload = gen_image(ContentFormat.PNG, 1, 1)
+        # TODO: Modify this test to use payload_path file streaming
 
-# Happy path:
-# - returns PersistResult with created=True
-# - item persisted in repo (get_by_full_hash returns it)
-# - bytes written to storage (storage.open returns content)
+        result = orch.ingest(payload_bytes=payload)
+        item, hash_full, code = result.item, result.item.hash_full, result.item.code
+
+        assert isinstance(result, PersistResult)
+        assert result.created
+        assert repo.get_by_full_hash(hash_full) == item
+        assert isinstance(item, PicItem)
+        with storage.open(code=code, format=item.format) as f:
+            assert f.read() == payload
+
+    def test_happy_path_link_item(self, test_orchestrator_env):
+        """LinkItem happy path: created=True, item in repo, NOT in storage."""
+        orch, repo, storage = test_orchestrator_env
+
+        result = orch.ingest(link_url="https://www.example.com/")
+        item, hash_full, code = result.item, result.item.hash_full, result.item.code
+
+        assert isinstance(result, PersistResult)
+        assert result.created
+        assert repo.get_by_full_hash(hash_full) == item
+        assert isinstance(item, LinkItem)
+        assert list(storage._root.glob(f"*{code}*")) == []


### PR DESCRIPTION
# Ft: Ingest orchestration layer

## Overview
Adds the orchestration layer coordinating
IngestService, Repository, & Storage into one entry point for the web layer.

## Changes

- `PersistResult` DTO for ingest results
- `IngestOrchestrator` with constructor and `ingest()` method
- Happy path for text, pic, and link items
- Dedupe handling (same hash returns existing item)
- Rollback on storage failure (repo cleanup + re-raise)
- `Repo.delete()` with FK CASCADE
- `PRAGMA foreign_keys = ON` in `init_db()`
- `link_url` support in `build_plan()` (explicit LinkItem creation)
- `PayloadKind.NONE` for link items
- `payload_bytes` populated in WritePlan
- Doc updates for service, repo, and v1 design

