### PR TITLE
Ft/CLI-Config-Selector

### DIFF
--- a/doc/design/patterns.md
+++ b/doc/design/patterns.md
@@ -73,57 +73,36 @@ def _from_magic_bytes(data: bytes) -> ContentClassification | None:
 Each detector handles one format's variants.
 Adding format = add detector + append to list.
 
-## Test Patterns
+## Service Layer Patterns
 
-### Pattern: Central Test Specs
+### Pattern: Services Write, Selectors Read
 
-```python
-_FORMAT_SPECS = [
-    (ContentFormat.PLAINTEXT, "text/plain", "txt", ItemKind.TEXT),
-    (ContentFormat.PNG, "image/png", "png", ItemKind.PICTURE),
-]
+Inspired by HackSoft's Django Styleguide services/selectors pattern,
+adapted for FastAPI with explicit dependency passing.
 
-_FMT_MIME = [(f, m) for f, m, _, _ in _FORMAT_SPECS]
-_FMT_EXT = [(f, e) for f, _, e, _ in _FORMAT_SPECS]
-```
-
-One tuple defines all relationships.
-Derived lists feed parametrized tests.
-Adding format = one row.
-
-### Pattern: Gap Detection Tests
+**Services** coordinate write operations (ingest, delete):
 
 ```python
-def test_all_formats_have_mime(self):
-    for fmt in ContentFormat:
-        result = mime_for_format(fmt)
-        assert isinstance(result, str)
+class IngestOrchestrator:
+    def __init__(self, ingest_service, repo, storage): ...
+    def ingest(self, ...) -> PersistResult: ...
 ```
 
-Loops over enum catch missing implementations.
-Fails when someone adds a format but forgets the mapping.
-
-### Pattern: Test Helper for Repeated Assertions
+**Selectors** coordinate read operations as module-level functions:
 
 ```python
-def _assert_content_class(result, expected_format, msg_prefix=""):
-    assert isinstance(result, ContentClassification)
-    assert result.format == expected_format
-    assert result.kind == kind_for_format(expected_format)
+def get_item(repo, code: str) -> TextItem | PicItem | LinkItem: ...
+def get_raw(repo, storage, code: str) -> tuple[BinaryIO | None, Item]: ...
 ```
 
-Centralizes multi-field assertions. Reduces boilerplate, improves error messages.
+Key differences from Django Styleguide:
 
-## Principles
+- Selectors take repo/storage as explicit parameters (no Django ORM globals)
+- No class needed for selectors — read coordination is simple
+- Naming is `selector.py` not `selectors.py` (matches depo's singular convention)
 
-- **Data structures are the spec**
-  - Mappings define behavior, functions just navigate them.
-- **Exhaustive tests over examples**
-  - Loop over enums, not cherry-picked cases.
-- **Fail at boundaries**
-  - Validate input at edges (web layer), trust types internally.
-- **Thin orchestrators**
-  - Complex behavior emerges from composing simple parts.
+The web layer talks exclusively to services/selectors.
+Routes never touch repo or storage directly.
 
 ## Coordination Patterns
 
@@ -197,6 +176,46 @@ then refactor to strategy pattern.
 
 YAGNI: don't abstract until the second case emerges.
 
+## Configuration Patterns
+
+### Pattern: Layered Config Resolution
+
+```python
+def load_config(*, config_path: Path | None = None) -> DepoConfig:
+    """Resolution: defaults → XDG → local → env → config_path"""
+```
+
+Each layer overrides the previous. Supports both containerized deployments
+(project-local `./depo.toml`) and traditional installs (XDG config path).
+
+- **Defaults** are hardcoded in a frozen dataclass
+- **Files** parsed via `tomllib` (stdlib, zero dependencies)
+- **Env vars** use `DEPO_` prefix with type coercion
+- **CLI flag** (`--config`) replaces file discovery entirely
+
+The config dataclass is the single source of truth for dependency wiring:
+
+```txt
+CLI loads DepoConfig → app_factory(config) → FastAPI app
+```
+
+### Pattern: Frozen Config as Dependency Root
+
+```python
+@dataclass(frozen=True)
+class DepoConfig:
+    db_path: Path
+    storage_root: Path
+    host: str
+    port: int
+    max_size_bytes: int
+    max_url_len: int
+```
+
+Frozen dataclass ensures config is immutable after resolution.
+All downstream components receive config values, never mutate them.
+App factory consumes config to wire all dependencies.
+
 ## Schema Patterns
 
 ### Pattern: Derived Fields at Read Time
@@ -226,3 +245,107 @@ def insert(
 Parameters with defaults for features not yet implemented (auth, permissions).
 Interface is stable—when feature lands, callers start passing real values.
 No signature change, no migration.
+
+## Test Patterns
+
+### Pattern: Centralized Fixtures with `t_` Prefix
+
+```python
+# tests/fixtures/__init__.py
+
+@pytest.fixture
+def t_conn() -> Generator[sqlite3.Connection, None, None]:
+    """Raw in-memory SQLite connection (no schema)."""
+    c = sqlite3.connect(":memory:")
+    yield c
+    c.close()
+
+@pytest.fixture
+def t_db() -> Generator[sqlite3.Connection, None, None]:
+    """In-memory SQLite repository with schema."""
+    c = sqlite3.connect(":memory:")
+    init_db(c)
+    yield c
+    c.close()
+
+@pytest.fixture
+def t_repo(t_db) -> SqliteRepository:
+    """SqliteRepository instance using in-memory DB."""
+    return SqliteRepository(t_db)
+
+@pytest.fixture
+def t_store(tmp_path) -> FilesystemStorage:
+    """FilesystemStorage instance with temporary root."""
+    return FilesystemStorage(root=tmp_path / "depo-test-store")
+
+@pytest.fixture
+def t_orch_env(
+    t_repo, t_store
+) -> tuple[IngestOrchestrator, SqliteRepository, FilesystemStorage]:
+    service = IngestService()
+    orch = IngestOrchestrator(service, t_repo, t_store)
+    return (orch, t_repo, t_store)
+```
+
+Fixtures compose upward: `t_conn` → `t_db` → `t_repo` → `t_orch_env`.
+Each layer adds one concern (schema, repository wrapper, orchestrator wiring).
+
+Key conventions:
+
+- `t_` prefix distinguishes first-party from pytest/third-party fixtures
+- `t_orch_env` returns a tuple so tests can access repo/storage for assertions
+- `t_store` uses `tmp_path` for automatic cleanup
+- `t_conn` exists for raw schema/SQL tests that don't need the full repo
+- Registered via `conftest.py` `pytest_plugins` for project-wide availability
+
+### Pattern: Central Test Specs
+
+```python
+_FORMAT_SPECS = [
+    (ContentFormat.PLAINTEXT, "text/plain", "txt", ItemKind.TEXT),
+    (ContentFormat.PNG, "image/png", "png", ItemKind.PICTURE),
+]
+
+_FMT_MIME = [(f, m) for f, m, _, _ in _FORMAT_SPECS]
+_FMT_EXT = [(f, e) for f, _, e, _ in _FORMAT_SPECS]
+```
+
+One tuple defines all relationships.
+Derived lists feed parametrized tests.
+Adding format = one row.
+
+### Pattern: Gap Detection Tests
+
+```python
+def test_all_formats_have_mime(self):
+    for fmt in ContentFormat:
+        result = mime_for_format(fmt)
+        assert isinstance(result, str)
+```
+
+Loops over enum catch missing implementations.
+Fails when someone adds a format but forgets the mapping.
+
+### Pattern: Test Helper for Repeated Assertions
+
+```python
+def _assert_content_class(result, expected_format, msg_prefix=""):
+    assert isinstance(result, ContentClassification)
+    assert result.format == expected_format
+    assert result.kind == kind_for_format(expected_format)
+```
+
+Centralizes multi-field assertions. Reduces boilerplate, improves error messages.
+
+## Principles
+
+- **Data structures are the spec**
+  - Mappings define behavior, functions just navigate them.
+- **Exhaustive tests over examples**
+  - Loop over enums, not cherry-picked cases.
+- **Fail at boundaries**
+  - Validate input at edges (web layer), trust types internally.
+- **Thin orchestrators**
+  - Complex behavior emerges from composing simple parts.
+- **Services write, selectors read**
+  - Clear separation between mutation and query paths.

--- a/doc/design/patterns.md
+++ b/doc/design/patterns.md
@@ -81,7 +81,6 @@ Inspired by HackSoft's Django Styleguide services/selectors pattern,
 adapted for FastAPI with explicit dependency passing.
 
 **Services** coordinate write operations (ingest, delete):
-
 ```python
 class IngestOrchestrator:
     def __init__(self, ingest_service, repo, storage): ...
@@ -89,14 +88,12 @@ class IngestOrchestrator:
 ```
 
 **Selectors** coordinate read operations as module-level functions:
-
 ```python
 def get_item(repo, code: str) -> TextItem | PicItem | LinkItem: ...
 def get_raw(repo, storage, code: str) -> tuple[BinaryIO | None, Item]: ...
 ```
 
 Key differences from Django Styleguide:
-
 - Selectors take repo/storage as explicit parameters (no Django ORM globals)
 - No class needed for selectors — read coordination is simple
 - Naming is `selector.py` not `selectors.py` (matches depo's singular convention)
@@ -194,7 +191,6 @@ Each layer overrides the previous. Supports both containerized deployments
 - **CLI flag** (`--config`) replaces file discovery entirely
 
 The config dataclass is the single source of truth for dependency wiring:
-
 ```txt
 CLI loads DepoConfig → app_factory(config) → FastAPI app
 ```
@@ -291,7 +287,6 @@ Fixtures compose upward: `t_conn` → `t_db` → `t_repo` → `t_orch_env`.
 Each layer adds one concern (schema, repository wrapper, orchestrator wiring).
 
 Key conventions:
-
 - `t_` prefix distinguishes first-party from pytest/third-party fixtures
 - `t_orch_env` returns a tuple so tests can access repo/storage for assertions
 - `t_store` uses `tmp_path` for automatic cleanup

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,13 @@ version = "0.0.0"
 description = "Content-addressed paste / image service"
 requires-python = ">=3.12"
 dependencies = [
+    "click>=8.3.1",
     "pillow>=12.1.0",
+    "rich>=14.3.2",
 ]
+
+[project.scripts]
+depo = "depo.cli.main:cli"
 
 [tool.uv]
 dev-dependencies = [

--- a/src/depo/__main__.py
+++ b/src/depo/__main__.py
@@ -1,0 +1,12 @@
+# src/depo/__main__.py
+"""
+Package entry point for `python -m depo`.
+
+Author: Marcus Grant
+Created: 2026-02-06
+License: Apache-2.0
+"""
+
+from depo.cli.main import cli
+
+cli()

--- a/src/depo/cli/config.py
+++ b/src/depo/cli/config.py
@@ -11,6 +11,7 @@ License: Apache-2.0
 """
 
 import os
+import tomllib
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -40,7 +41,80 @@ class DepoConfig:
     db_path: Path = field(default_factory=_default_db_path)
     # Network
     host: str = "127.0.0.1"
-    port: int = 8000
-    # Payload limits
+    port: int = 8765
+    # Limits/thresholds
     max_size_bytes: int = 10_485_760
     max_url_len: int = 2048
+
+
+def _xdg_config_home() -> Path:
+    xdg = os.environ.get("XDG_CONFIG_HOME")
+    if xdg:
+        return Path(xdg)
+    return Path.home() / ".config"
+
+
+def _load_toml(path: Path) -> dict:
+    if path.is_file():
+        with open(path, "rb") as f:
+            return tomllib.load(f)
+    return {}
+
+
+def _coerce(overrides: dict) -> dict:
+    """Coerce string values from env/TOML to expected types."""
+    int_fields = {"port", "max_size_bytes", "max_url_len"}
+    path_fields = {"db_path", "store_root"}
+    out = {}
+    for k, v in overrides.items():
+        if k in int_fields:
+            out[k] = int(v)
+        elif k in path_fields:
+            out[k] = Path(v).expanduser()
+        else:
+            out[k] = v
+    return out
+
+
+def _env_overrides() -> dict:
+    """Collect DEPO_* env vars, stripped of prefix and lowercased."""
+    prefix = "DEPO_"
+    out = {}
+    for k, v in os.environ.items():
+        if k.startswith(prefix):
+            out[k[len(prefix) :].lower()] = v
+    return out
+
+
+def load_config(*, config_path: Path | None = None) -> DepoConfig:
+    """
+    Build DepoConfig from layered sources.
+
+    Resolution:
+        defaults → XDG config.toml → ./depo.toml → DEPO_* env → config_path flag.
+
+    Args:
+        config_path: Explicit TOML path (--config flag). Replaces XDG/local resolution.
+
+    Returns:
+        Resolved DepoConfig.
+
+    Raises:
+        FileNotFoundError: If config_path provided but missing.
+    """
+    overrides: dict = {}
+
+    if config_path is not None:
+        if not config_path.is_file():
+            raise FileNotFoundError(config_path)
+        overrides.update(_load_toml(config_path))
+    else:
+        # XDG config
+        overrides.update(_load_toml(_xdg_config_home() / "depo" / "config.toml"))
+        # Local ./depo.toml
+        overrides.update(_load_toml(Path.cwd() / "depo.toml"))
+
+    # Env vars layer on top of everything
+    overrides.update(_env_overrides())
+
+    return DepoConfig(**_coerce(overrides))

--- a/src/depo/cli/config.py
+++ b/src/depo/cli/config.py
@@ -1,0 +1,46 @@
+# src/depo/cli/config.py
+"""
+Application configuration.
+
+Frozen dataclass with layered resolution:
+defaults → XDG config.toml → ./depo.toml → DEPO_* env → --config flag.
+
+Author: Marcus Grant
+Created: 2026-02-06
+License: Apache-2.0
+"""
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+_XDG_DATA_HOME = "XDG_DATA_HOME"
+
+
+def _default_store_dir() -> Path:
+    """Return XDG_DATA_HOME/depo if set, else ./store for containerized deploys."""
+    if xdg := os.environ.get(_XDG_DATA_HOME):
+        return Path(xdg) / "depo" / "store"
+    return Path.cwd() / "store"
+
+
+def _default_db_path() -> Path:
+    """Return default database path. XDG_DATA_HOME/depo/depo.db or ./depo.db."""
+    if xdg := os.environ.get(_XDG_DATA_HOME):
+        return Path(xdg) / "depo" / "depo.db"
+    return Path.cwd() / "depo.db"
+
+
+@dataclass(frozen=True, kw_only=True)
+class DepoConfig:
+    """Immutable application configuration."""
+
+    # Paths / Dirs
+    store_root: Path = field(default_factory=_default_store_dir)
+    db_path: Path = field(default_factory=_default_db_path)
+    # Network
+    host: str = "127.0.0.1"
+    port: int = 8000
+    # Payload limits
+    max_size_bytes: int = 10_485_760
+    max_url_len: int = 2048

--- a/src/depo/cli/main.py
+++ b/src/depo/cli/main.py
@@ -7,20 +7,38 @@ Created: 2026-02-09
 License: Apache-2.0
 """
 
+import sqlite3
+from dataclasses import fields
+
 import click
+from rich.console import Console
+from rich.table import Table
 
 from depo.cli.config import DepoConfig, load_config
+from depo.repo.sqlite import init_db
 
 
 @click.group()
-def cli() -> None:
+@click.pass_context
+def cli(ctx: click.Context) -> None:
     """depo — content-addressed paste/image service."""
+    ctx.ensure_object(dict)
+    if "config" not in ctx.obj:
+        ctx.obj["config"] = load_config()
 
 
 @cli.command()
-def init() -> None:
+@click.pass_context
+def init(ctx: click.Context) -> None:
     """Initialize storage directories and database."""
-    raise NotImplementedError
+    cfg: DepoConfig = ctx.obj["config"]
+    cfg.db_path.parent.mkdir(parents=True, exist_ok=True)
+    cfg.store_root.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(cfg.db_path))
+    try:
+        init_db(conn)
+    finally:
+        conn.close()
 
 
 @cli.command()
@@ -35,6 +53,14 @@ def config() -> None:
 
 
 @config.command("show")
-def config_show() -> None:
+@click.pass_context
+def config_show(ctx: click.Context) -> None:
     """Display resolved configuration."""
-    raise NotImplementedError
+    cfg: DepoConfig = ctx.obj["config"]
+    table = Table(title="Depo Configuration", show_header=False)
+    table.add_column("Key", style="bold blue")
+    table.add_column("Value")
+    for f in fields(cfg):
+        table.add_row(f.name, str(getattr(cfg, f.name)))
+    console = Console()
+    console.print(table)

--- a/src/depo/cli/main.py
+++ b/src/depo/cli/main.py
@@ -1,0 +1,40 @@
+# src/depo/cli/main.py
+"""
+CLI entry point using Click.
+
+Author: Marcus Grant
+Created: 2026-02-09
+License: Apache-2.0
+"""
+
+import click
+
+from depo.cli.config import DepoConfig, load_config
+
+
+@click.group()
+def cli() -> None:
+    """depo — content-addressed paste/image service."""
+
+
+@cli.command()
+def init() -> None:
+    """Initialize storage directories and database."""
+    raise NotImplementedError
+
+
+@cli.command()
+def serve() -> None:
+    """Start the web server."""
+    raise NotImplementedError
+
+
+@cli.group()
+def config() -> None:
+    """Configuration management."""
+
+
+@config.command("show")
+def config_show() -> None:
+    """Display resolved configuration."""
+    raise NotImplementedError

--- a/src/depo/cli/main.py
+++ b/src/depo/cli/main.py
@@ -42,9 +42,11 @@ def init(ctx: click.Context) -> None:
 
 
 @cli.command()
-def serve() -> None:
+@click.pass_context
+def serve(ctx: click.Context) -> None:
     """Start the web server."""
-    raise NotImplementedError
+    cfg: DepoConfig = ctx.obj["config"]
+    click.echo(f"Starting depo on {cfg.host}:{cfg.port} (not implemented)")
 
 
 @cli.group()

--- a/src/depo/repo/errors.py
+++ b/src/depo/repo/errors.py
@@ -17,3 +17,11 @@ class CodeCollisionError(RepoError):
     def __init__(self, code: str):
         self.code = code
         super().__init__(f"Code collision: {code}")
+
+
+class NotFoundError(RepoError):
+    """Lookup found no matching item."""
+
+    def __init__(self, code: str):
+        self.code = code
+        super().__init__(f"Item not found: {code}")

--- a/src/depo/service/selector.py
+++ b/src/depo/service/selector.py
@@ -37,38 +37,15 @@ def get_item(repo: SqliteRepository, code: str) -> TextItem | PicItem | LinkItem
     raise NotFoundError(code)
 
 
-def get_raw(
-    repo: SqliteRepository, storage: StorageBackend, code: str
-) -> tuple[BinaryIO | None, TextItem | PicItem | LinkItem]:
+def get_raw(store: StorageBackend, item: TextItem | PicItem) -> BinaryIO:
     """
-    Fetch item and its payload handle.
+    Open payload for reading.
 
     Args:
-        repo: Repository instance.
-        storage: Storage backend.
-        code: Short code identifier.
+        store: Storage backend.
+        item: Item with format and code (must have payload).
 
     Returns:
-        (file_handle, item) for TextItem/PicItem; (None, item) for LinkItem.
-
-    Raises:
-        NotFoundError: If code not found.
+        Binary file handle. Caller responsible for closing.
     """
-    raise NotImplementedError
-
-
-def get_info(repo: SqliteRepository, code: str) -> TextItem | PicItem | LinkItem:
-    """
-    Fetch item metadata. Thin wrapper today, seam for future enrichment.
-
-    Args:
-        repo: Repository instance.
-        code: Short code identifier.
-
-    Returns:
-        Resolved item.
-
-    Raises:
-        NotFoundError: If code not found.
-    """
-    raise NotImplementedError
+    return store.open(code=item.code, format=item.format)

--- a/src/depo/service/selector.py
+++ b/src/depo/service/selector.py
@@ -1,0 +1,74 @@
+# src/depo/service/selector.py
+"""
+Read-path selectors for content items.
+
+Services write, selectors read. Module-level functions
+that operate on repo and storage dependencies.
+
+Author: Marcus Grant
+Created: 2026-02-06
+License: Apache-2.0
+"""
+
+from typing import BinaryIO
+
+from depo.model.item import LinkItem, PicItem, TextItem
+from depo.repo.errors import NotFoundError
+from depo.repo.sqlite import SqliteRepository
+from depo.storage.protocol import StorageBackend
+
+
+def get_item(repo: SqliteRepository, code: str) -> TextItem | PicItem | LinkItem:
+    """
+    Fetch item by short code.
+
+    Args:
+        repo: Repository instance.
+        code: Short code identifier.
+
+    Returns:
+        Resolved item.
+
+    Raises:
+        NotFoundError: If code not found.
+    """
+    if item := repo.get_by_code(code):
+        return item
+    raise NotFoundError(code)
+
+
+def get_raw(
+    repo: SqliteRepository, storage: StorageBackend, code: str
+) -> tuple[BinaryIO | None, TextItem | PicItem | LinkItem]:
+    """
+    Fetch item and its payload handle.
+
+    Args:
+        repo: Repository instance.
+        storage: Storage backend.
+        code: Short code identifier.
+
+    Returns:
+        (file_handle, item) for TextItem/PicItem; (None, item) for LinkItem.
+
+    Raises:
+        NotFoundError: If code not found.
+    """
+    raise NotImplementedError
+
+
+def get_info(repo: SqliteRepository, code: str) -> TextItem | PicItem | LinkItem:
+    """
+    Fetch item metadata. Thin wrapper today, seam for future enrichment.
+
+    Args:
+        repo: Repository instance.
+        code: Short code identifier.
+
+    Returns:
+        Resolved item.
+
+    Raises:
+        NotFoundError: If code not found.
+    """
+    raise NotImplementedError

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -7,6 +7,7 @@ Created: 2026-02-06
 License: Apache-2.0
 """
 
+import os
 from pathlib import Path
 
 import pytest
@@ -17,7 +18,25 @@ from depo.cli.config import (
     DepoConfig,
     _default_db_path,
     _default_store_dir,
+    load_config,
 )
+
+
+def _clear_depo_env(monkeypatch):
+    for key in list(os.environ):
+        if key.startswith("DEPO_"):
+            monkeypatch.delenv(key)
+
+
+def _write_toml(path: Path, **kwargs) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = []
+    for k, v in kwargs.items():
+        if isinstance(v, str):
+            lines.append(f'{k} = "{v}"')
+        else:
+            lines.append(f"{k} = {v}")
+    path.write_text("\n".join(lines) + "\n")
 
 
 class TestDefaultPaths:
@@ -47,7 +66,7 @@ class TestDepoConfig:
         ("name", "typ", "required", "default"),
         [
             ("host", str, False, "127.0.0.1"),
-            ("port", int, False, 8000),
+            ("port", int, False, 8765),
             ("max_size_bytes", int, False, 10_485_760),
             ("max_url_len", int, False, 2048),
         ],
@@ -76,3 +95,126 @@ class TestDepoConfig:
         assert cfg.port == 3000
         assert cfg.max_size_bytes == 10_485_760
         assert cfg.max_url_len == 2048
+
+
+class TestLoadConfigToml:
+    """Tests for TOML file resolution chain."""
+
+    def test_xdg_config_overrides_defaults(self, monkeypatch, tmp_path):
+        _clear_depo_env(monkeypatch)
+        toml_cfgs = {"host": "0.0.0.0", "port": 9000}
+        _write_toml(tmp_path / "xdg/depo/config.toml", **toml_cfgs)
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+        monkeypatch.chdir(tmp_path)
+        cfg = load_config()
+        assert cfg.host == "0.0.0.0"
+        assert cfg.port == 9000
+        assert cfg.max_size_bytes == 10_485_760
+
+    def test_local_toml_overrides_xdg(self, monkeypatch, tmp_path):
+        _clear_depo_env(monkeypatch)
+        # XDG says port 9000
+        xdg_cfg = tmp_path / "xdg"
+        (xdg_cfg / "depo").mkdir(parents=True)
+        (xdg_cfg / "depo" / "config.toml").write_text("port = 9000\n")
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_cfg))
+        # Local says port 7000
+        workdir = tmp_path / "project"
+        workdir.mkdir()
+        (workdir / "depo.toml").write_text("port = 7000\n")
+        monkeypatch.chdir(workdir)
+        cfg = load_config()
+        assert cfg.port == 7000
+
+    def test_partial_toml_preserves_defaults(self, monkeypatch, tmp_path):
+        _clear_depo_env(monkeypatch)
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
+        workdir = tmp_path / "proj"
+        workdir.mkdir()
+        (workdir / "depo.toml").write_text('host = "10.0.0.1"\n')
+        monkeypatch.chdir(workdir)
+        cfg = load_config()
+        assert cfg.host == "10.0.0.1"
+        assert cfg.port == 8765
+        assert cfg.max_url_len == 2048
+
+
+class TestLoadConfigEnv:
+    """Tests for DEPO_* environment variable overrides."""
+
+    def _clear_depo_env(self, monkeypatch):
+        for key in list(os.environ):
+            if key.startswith("DEPO_"):
+                monkeypatch.delenv(key)
+
+    def test_env_overrides_toml(self, monkeypatch, tmp_path):
+        self._clear_depo_env(monkeypatch)
+        workdir = tmp_path / "proj"
+        workdir.mkdir()
+        _write_toml(workdir / "depo.toml", port=7000)
+        monkeypatch.chdir(workdir)
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
+        monkeypatch.setenv("DEPO_PORT", "5555")
+        cfg = load_config()
+        assert cfg.port == 5555
+
+    def test_env_host(self, monkeypatch, tmp_path):
+        self._clear_depo_env(monkeypatch)
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("DEPO_HOST", "192.168.1.1")
+        cfg = load_config()
+        assert cfg.host == "192.168.1.1"
+
+    def test_env_path_expansion(self, monkeypatch, tmp_path):
+        self._clear_depo_env(monkeypatch)
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("DEPO_DB_PATH", "~/my-depo/data.db")
+        cfg = load_config()
+        assert cfg.db_path == Path.home() / "my-depo/data.db"
+
+    def test_env_int_coercion(self, monkeypatch, tmp_path):
+        self._clear_depo_env(monkeypatch)
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("DEPO_MAX_SIZE_BYTES", "5242880")
+        cfg = load_config()
+        assert cfg.max_size_bytes == 5_242_880
+
+
+class TestLoadConfigFlag:
+    """Tests for config_path parameter (--config flag)."""
+
+    def _clear_depo_env(self, monkeypatch):
+        for key in list(os.environ):
+            if key.startswith("DEPO_"):
+                monkeypatch.delenv(key)
+
+    def test_config_path_overrides_toml_chain(self, monkeypatch, tmp_path):
+        self._clear_depo_env(monkeypatch)
+        _write_toml(tmp_path / "xdg/depo/config.toml", port=9000)
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+        monkeypatch.chdir(tmp_path)
+        explicit = tmp_path / "custom.toml"
+        _write_toml(explicit, port=1234)
+        cfg = load_config(config_path=explicit)
+        assert cfg.port == 1234
+
+    def test_missing_config_path_raises(self, monkeypatch, tmp_path):
+        self._clear_depo_env(monkeypatch)
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
+        monkeypatch.chdir(tmp_path)
+        with pytest.raises(FileNotFoundError):
+            load_config(config_path=tmp_path / "nonexistent.toml")
+
+    def test_env_layers_on_config_path(self, monkeypatch, tmp_path):
+        self._clear_depo_env(monkeypatch)
+        explicit = tmp_path / "custom.toml"
+        _write_toml(explicit, port=1234)
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("DEPO_HOST", "10.0.0.5")
+        cfg = load_config(config_path=explicit)
+        assert cfg.port == 1234
+        assert cfg.host == "10.0.0.5"

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -1,0 +1,78 @@
+# tests/cli/test_config.py
+"""
+Tests for CLI configuration.
+
+Author: Marcus Grant
+Created: 2026-02-06
+License: Apache-2.0
+"""
+
+from pathlib import Path
+
+import pytest
+from tests.helpers.assertions import assert_field
+
+from depo.cli.config import (
+    _XDG_DATA_HOME,
+    DepoConfig,
+    _default_db_path,
+    _default_store_dir,
+)
+
+
+class TestDefaultPaths:
+    """Tests for path resolution helpers."""
+
+    def test_store_dir_xdg(self, monkeypatch, tmp_path):
+        monkeypatch.setenv(_XDG_DATA_HOME, str(tmp_path))
+        assert _default_store_dir() == tmp_path / "depo" / "store"
+
+    def test_store_dir_fallback(self, monkeypatch):
+        monkeypatch.delenv(_XDG_DATA_HOME, raising=False)
+        assert _default_store_dir() == Path.cwd() / "store"
+
+    def test_db_path_xdg(self, monkeypatch, tmp_path):
+        monkeypatch.setenv(_XDG_DATA_HOME, str(tmp_path))
+        assert _default_db_path() == tmp_path / "depo" / "depo.db"
+
+    def test_db_path_fallback(self, monkeypatch):
+        monkeypatch.delenv(_XDG_DATA_HOME, raising=False)
+        assert _default_db_path() == Path.cwd() / "depo.db"
+
+
+class TestDepoConfig:
+    """Tests for DepoConfig frozen dataclass."""
+
+    @pytest.mark.parametrize(
+        ("name", "typ", "required", "default"),
+        [
+            ("host", str, False, "127.0.0.1"),
+            ("port", int, False, 8000),
+            ("max_size_bytes", int, False, 10_485_760),
+            ("max_url_len", int, False, 2048),
+        ],
+    )
+    def test_simple_fields(self, name, typ, required, default):
+        assert_field(DepoConfig, name, typ, required, default)
+
+    @pytest.mark.parametrize("name", ["db_path", "store_root"])
+    def test_path_fields_are_paths(self, name):
+        """Factory defaults resolve to Path — value depends on env."""
+        cfg = DepoConfig()
+        assert isinstance(getattr(cfg, name), Path)
+
+    def test_frozen(self):
+        cfg = DepoConfig()
+        with pytest.raises(AttributeError):
+            cfg.port = 9999  # type: ignore[misc]
+
+    def test_keyword_only(self):
+        with pytest.raises(TypeError):
+            DepoConfig("127.0.0.1")  # type: ignore[misc]
+
+    def test_override_preserves_defaults(self):
+        cfg = DepoConfig(host="0.0.0.0", port=3000)
+        assert cfg.host == "0.0.0.0"
+        assert cfg.port == 3000
+        assert cfg.max_size_bytes == 10_485_760
+        assert cfg.max_url_len == 2048

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -1,0 +1,22 @@
+# tests/cli/test_main.py
+"""
+Tests for CLI commands.
+
+Author: Marcus Grant
+Created: 2026-02-09
+License: Apache-2.0
+"""
+
+import pytest
+from click.testing import CliRunner
+
+from depo.cli.main import cli
+
+
+class TestInit:
+    """Tests for `depo init`."""
+
+    # - creates db_path parent directory
+    # - creates store_root directory
+    # - idempotent (succeeds when dirs already exist)
+    # - initializes database schema (depo.db created)

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -10,7 +10,6 @@ License: Apache-2.0
 from dataclasses import fields
 from pathlib import Path
 
-import pytest
 from click.testing import CliRunner
 
 from depo.cli.config import DepoConfig
@@ -76,3 +75,12 @@ class TestConfigShow:
         )
         assert "10.0.0.1" in result.output
         assert "3000" in result.output
+
+
+class TestServe:
+    """Tests for `depo serve`."""
+
+    def test_placeholder(self, tmp_path):
+        result = _invoke("serve", tmp_path=tmp_path)
+        assert result.exit_code == 0
+        assert "not implemented" in result.output.lower()

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -7,16 +7,72 @@ Created: 2026-02-09
 License: Apache-2.0
 """
 
+from dataclasses import fields
+from pathlib import Path
+
 import pytest
 from click.testing import CliRunner
 
+from depo.cli.config import DepoConfig
 from depo.cli.main import cli
+
+
+# TODO: Should this be a fixture?
+def _depo_cfg(p: Path) -> DepoConfig:
+    return DepoConfig(db_path=p / "data" / "depo.db", store_root=p / "store")
+
+
+def _invoke(*args, tmp_path: Path | None = None):
+    cfg = _depo_cfg(tmp_path) if tmp_path else DepoConfig()
+    runner = CliRunner()
+    return runner.invoke(cli, list(args), obj={"config": cfg}, env={"COLUMNS": "300"})  # type: ignore
 
 
 class TestInit:
     """Tests for `depo init`."""
 
-    # - creates db_path parent directory
-    # - creates store_root directory
-    # - idempotent (succeeds when dirs already exist)
-    # - initializes database schema (depo.db created)
+    def test_creates_directories(self, tmp_path):
+        result = _invoke("init", tmp_path=tmp_path)
+        assert result.exit_code == 0
+        assert (tmp_path / "data").is_dir()
+        assert (tmp_path / "store").is_dir()
+
+    def test_creates_database(self, tmp_path):
+        _invoke("init", tmp_path=tmp_path)
+        assert _depo_cfg(tmp_path).db_path.is_file()
+
+    def test_idempotent(self, tmp_path):
+        _invoke("init", tmp_path=tmp_path)
+        result = _invoke("init", tmp_path=tmp_path)
+        assert result.exit_code == 0
+
+
+class TestConfigShow:
+    """Tests for `depo config show`."""
+
+    def test_prints_all_cfg_fields(self, tmp_path):
+        """Prints all expected config fields & shows exit code 0"""
+        result = _invoke("config", "show", tmp_path=tmp_path)
+        assert result.exit_code == 0
+        assert "store" in result.output
+        assert "depo.db" in result.output
+        assert str(_depo_cfg(tmp_path).host) in result.output
+        assert str(_depo_cfg(tmp_path).port) in result.output
+        assert str(_depo_cfg(tmp_path).max_size_bytes) in result.output
+        assert str(_depo_cfg(tmp_path).max_url_len) in result.output
+
+    def test_shows_all_expected_fields(self, tmp_path):
+        """Tests gaps in coverage for new/different DepoConfig fields"""
+        result = _invoke("config", "show", tmp_path=tmp_path)
+        for f in fields(DepoConfig):
+            assert f.name in result.output
+
+    def test_reflects_overrides(self):
+        """Shows overridden values, not defaults."""
+        cfg = DepoConfig(host="10.0.0.1", port=3000)
+        runner = CliRunner()
+        result = runner.invoke(  # Doesnt use _invoke to modify config overrides
+            cli, ["config", "show"], obj={"config": cfg}, env={"COLUMNS": "300"}
+        )
+        assert "10.0.0.1" in result.output
+        assert "3000" in result.output

--- a/tests/factories/db.py
+++ b/tests/factories/db.py
@@ -1,0 +1,146 @@
+# tests/factories/db.py
+"""
+Database seed helpers for integration tests.
+
+Raw SQL inserts that bypass the repo layer to
+establish known DB state.
+
+Author: Marcus Grant
+Created: 2026-02-06
+License: Apache-2.0
+"""
+
+import sqlite3
+
+from depo.model.enums import ContentFormat, Visibility
+from depo.model.item import ItemKind, LinkItem, PicItem, TextItem
+
+
+def insert_text_item(
+    conn: sqlite3.Connection,
+    hash_full: str = "ABC1234506789DEFGHKMNPQR",
+    code: str = "ABCD1234",
+    size_b: int = 99,
+    uid: int = 0,
+    perm: Visibility = Visibility.PUBLIC,
+    upload_at: int = 123456789,
+    origin_at: int | None = None,
+    format: ContentFormat = ContentFormat.PLAINTEXT,
+) -> TextItem:
+    """Insert a TextItem via raw SQL and return the domain object."""
+    conn.execute(
+        "INSERT INTO items"
+        "(hash_full, code, kind, size_b, uid, perm, upload_at, origin_at)"
+        "VALUES (?, ?, 'txt', ?, ?, ?, ?, ?)",
+        (hash_full, code, size_b, uid, perm, upload_at, origin_at),
+    )
+    conn.execute(
+        "INSERT INTO text_items (hash_full, format) VALUES (?, ?)",
+        (hash_full, format),
+    )
+    return TextItem(
+        hash_full=hash_full,
+        code=code,
+        kind=ItemKind.TEXT,
+        size_b=size_b,
+        uid=uid,
+        perm=perm,
+        upload_at=upload_at,
+        origin_at=origin_at,
+        format=format,
+    )
+
+
+def insert_pic_item(
+    conn: sqlite3.Connection,
+    hash_full: str = "ABC1234506789DEFGHKMNPQR",
+    code: str = "ABCD1234",
+    size_b: int = 99,
+    uid: int = 0,
+    perm: Visibility = Visibility.PUBLIC,
+    upload_at: int = 123456789,
+    origin_at: int | None = None,
+    format: ContentFormat = ContentFormat.JPEG,
+    width: int = 320,
+    height: int = 240,
+) -> PicItem:
+    """Insert a PicItem via raw SQL and return the domain object."""
+    conn.execute(
+        "INSERT INTO items"
+        "(hash_full, code, kind, size_b, uid, perm, upload_at, origin_at)"
+        "VALUES (?, ?, 'pic', ?, ?, ?, ?, ?)",
+        (hash_full, code, size_b, uid, perm, upload_at, origin_at),
+    )
+    conn.execute(
+        "INSERT INTO pic_items (hash_full, format, width, height) VALUES (?, ?, ?, ?)",
+        (hash_full, format, width, height),
+    )
+    return PicItem(
+        hash_full=hash_full,
+        code=code,
+        kind=ItemKind.PICTURE,
+        size_b=size_b,
+        uid=uid,
+        perm=perm,
+        upload_at=upload_at,
+        origin_at=origin_at,
+        format=format,
+        width=width,
+        height=height,
+    )
+
+
+def insert_link_item(
+    conn: sqlite3.Connection,
+    hash_full: str = "ABC1234506789DEFGHKMNPQR",
+    code: str = "ABCD1234",
+    size_b: int = 99,
+    uid: int = 0,
+    perm: Visibility = Visibility.PUBLIC,
+    upload_at: int = 123456789,
+    origin_at: int | None = None,
+    url: str = "https://example.com",
+) -> LinkItem:
+    """Insert a LinkItem via raw SQL and return the domain object."""
+
+    conn.execute(
+        "INSERT INTO items"
+        "(hash_full, code, kind, size_b, uid, perm, upload_at, origin_at)"
+        "VALUES (?, ?, 'url', ?, ?, ?, ?, ?)",
+        (hash_full, code, size_b, uid, perm, upload_at, origin_at),
+    )
+    conn.execute(
+        "INSERT INTO link_items (hash_full, url) VALUES (?, ?)",
+        (hash_full, url),
+    )
+    return LinkItem(
+        hash_full=hash_full,
+        code=code,
+        kind=ItemKind.LINK,
+        size_b=size_b,
+        uid=uid,
+        perm=perm,
+        upload_at=upload_at,
+        origin_at=origin_at,
+        url=url,
+    )
+
+
+def seed_all_types(conn: sqlite3.Connection) -> tuple[TextItem, PicItem, LinkItem]:
+    """
+    Insert one TextItem, PicItem, LinkItem with distinct hashes/codes.
+
+    Returns:
+        (TextItem, PicItem, LinkItem) tuple of inserted items.
+        Note: hash_full and code values are derived from:
+        {T, P, L} + first chars of crockford alphabet for easy verification.
+    """
+    hash_suffix = "0123456789ABCDEFGHJKMNP"  # Use first 23 of crockford alphabet
+    txt_prefix, pic_prefix, link_prefix = "T", "P", "L"
+    txt_hash, txt_code = txt_prefix + hash_suffix, txt_prefix + hash_suffix[:8]
+    pic_hash, pic_code = pic_prefix + hash_suffix, pic_prefix + hash_suffix[:8]
+    link_hash, link_code = link_prefix + hash_suffix, link_prefix + hash_suffix[:8]
+    txt_item = insert_text_item(conn, hash_full=txt_hash, code=txt_code)
+    pic_item = insert_pic_item(conn, hash_full=pic_hash, code=pic_code)
+    link_item = insert_link_item(conn, hash_full=link_hash, code=link_code)
+    return (txt_item, pic_item, link_item)

--- a/tests/helpers/assertions.py
+++ b/tests/helpers/assertions.py
@@ -14,7 +14,15 @@ from depo.model.enums import ItemKind, Visibility
 from depo.model.item import Item
 
 
-def assert_field(cls: type, name: str, typ: type, required: bool, default: Any) -> None:
+def assert_field(
+    cls: type,
+    name: str,
+    typ: type,
+    required: bool,
+    default: Any,
+    *,
+    factory: bool = False,
+) -> None:
     """
     Assert a dataclass field has the expected specification.
 
@@ -42,7 +50,13 @@ def assert_field(cls: type, name: str, typ: type, required: bool, default: Any) 
     f = field_map[name]
     assert f.type == typ, f"{name} type mismatch: expected {typ}, got {f.type}"
     if required:
-        assert f.default is MISSING, f"{name} should be required"
+        msg = f"{name} should be required"
+        assert f.default is MISSING and f.default_factory is MISSING, msg
+    elif factory:
+        assert f.default_factory is not MISSING, f"{name} should use default_factory"
+        msg = f"{name} factory default mismatch: "
+        msg += f"expected {default}, got {f.default_factory()}"
+        assert f.default_factory() == default, msg
     else:
         msg = f"{name} default mismatch: expected {default}, got {f.default}"
         assert f.default == default, msg

--- a/tests/service/test_selector.py
+++ b/tests/service/test_selector.py
@@ -1,0 +1,45 @@
+# tests/service/test_selector.py
+"""
+Tests for selector read-path functions.
+
+Author: Marcus Grant
+Created: 2026-02-06
+License: Apache-2.0
+"""
+
+import pytest
+from tests.factories.db import seed_all_types
+
+from depo.repo.errors import NotFoundError
+from depo.service.selector import get_info, get_item, get_raw
+
+
+class TestGetItem:
+    """Tests for get_item()."""
+
+    def test_item_when_code_exists(self, t_db, t_repo):
+        """Returns correct Item when code exists as Item"""
+        txt_item, pic_item, link_item = seed_all_types(t_db)
+        assert get_item(t_repo, txt_item.code) == txt_item
+        assert get_item(t_repo, pic_item.code) == pic_item
+        assert get_item(t_repo, link_item.code) == link_item
+
+    def test_raises_not_found_when_code_missing(self, t_repo):
+        """Raises NotFoundError when code missing"""
+        with pytest.raises(NotFoundError):
+            get_item(t_repo, "N0TEX1ST")
+
+
+class TestGetRaw:
+    """Tests for get_raw()."""
+
+    # - returns (file_handle, item) for TextItem/PicItem
+    # - returns (None, item) for LinkItem
+    # - raises NotFoundError when code missing
+
+
+class TestGetInfo:
+    """Tests for get_info()."""
+
+    # - returns item when code exists
+    # - raises NotFoundError when code missing

--- a/uv.lock
+++ b/uv.lock
@@ -60,7 +60,9 @@ name = "depo"
 version = "0.0.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "click" },
     { name = "pillow" },
+    { name = "rich" },
 ]
 
 [package.dev-dependencies]
@@ -73,7 +75,11 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pillow", specifier = ">=12.1.0" }]
+requires-dist = [
+    { name = "click", specifier = ">=8.3.1" },
+    { name = "pillow", specifier = ">=12.1.0" },
+    { name = "rich", specifier = ">=14.3.2" },
+]
 
 [package.metadata.requires-dev]
 dev = [
@@ -152,6 +158,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/22/f0/07fb6ab5c39a4ca9af3e37554f9d42f25c464829254d72e4ebbd81da351c/librt-0.7.8-cp314-cp314t-win32.whl", hash = "sha256:171ca3a0a06c643bd0a2f62a8944e1902c94aa8e5da4db1ea9a8daf872685365", size = 41173, upload-time = "2026-01-14T12:55:59.315Z" },
     { url = "https://files.pythonhosted.org/packages/24/d4/7e4be20993dc6a782639625bd2f97f3c66125c7aa80c82426956811cfccf/librt-0.7.8-cp314-cp314t-win_amd64.whl", hash = "sha256:445b7304145e24c60288a2f172b5ce2ca35c0f81605f5299f3fa567e189d2e32", size = 47668, upload-time = "2026-01-14T12:56:00.261Z" },
     { url = "https://files.pythonhosted.org/packages/fc/85/69f92b2a7b3c0f88ffe107c86b952b397004b5b8ea5a81da3d9c04c04422/librt-0.7.8-cp314-cp314t-win_arm64.whl", hash = "sha256:8766ece9de08527deabcd7cb1b4f1a967a385d26e33e536d6d8913db6ef74f06", size = 40550, upload-time = "2026-01-14T12:56:01.542Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -346,6 +373,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4e/8d/a762be14dae1c3bf280202ba3172020b2b0b4c537f94427435f19c413b72/pytokens-0.3.0.tar.gz", hash = "sha256:2f932b14ed08de5fcf0b391ace2642f858f1394c0857202959000b68ed7a458a", size = 17644, upload-time = "2025-11-05T13:36:35.34Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/84/25/d9db8be44e205a124f6c98bc0324b2bb149b7431c53877fc6d1038dddaf5/pytokens-0.3.0-py3-none-any.whl", hash = "sha256:95b2b5eaf832e469d141a378872480ede3f251a5a5041b8ec6e581d3ac71bbf3", size = 12195, upload-time = "2025-11-05T13:36:33.183Z" },
+]
+
+[[package]]
+name = "rich"
+version = "14.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/99/a4cab2acbb884f80e558b0771e97e21e939c5dfb460f488d19df485e8298/rich-14.3.2.tar.gz", hash = "sha256:e712f11c1a562a11843306f5ed999475f09ac31ffb64281f73ab29ffdda8b3b8", size = 230143, upload-time = "2026-02-01T16:20:47.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/45/615f5babd880b4bd7d405cc0dc348234c5ffb6ed1ea33e152ede08b2072d/rich-14.3.2-py3-none-any.whl", hash = "sha256:08e67c3e90884651da3239ea668222d19bea7b589149d8014a21c633420dbb69", size = 309963, upload-time = "2026-02-01T16:20:46.078Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# CLI/Config + Selector

Adds configuration resolution, CLI entry points, and read-path selectors.

## Config

- `DepoConfig` frozen dataclass with XDG-compliant defaults
- Layered resolution:
  - defaults -> XDG config.toml
  - XDG config.toml -> ./depo.toml
  - ./depo.toml -> DEPO_* env
  - DEPO_* env -> --config flag
- DB and store paths resolve independently

## Selector

- `get_item(repo, code)` and `get_raw(storage, item)` as module-level functions
- Services write, selectors read pattern
- `get_info` dropped — redundant with `get_item` at MVP

## CLI

- Click group with config at group level via `ctx.obj`
- `init`, `config show`, `serve` (placeholder)
- `python -m depo` entry point
- `NotFoundError` added to repo errors
