### PR TITLE
PR: Browser/HTML

### DIFF
--- a/doc/design/README.md
+++ b/doc/design/README.md
@@ -81,3 +81,7 @@ IngestOrchestrator coordinates Repository and StorageBackend as siblings.
 - [Development Process](./process.md)
   - Principles and learnings about how we develop depo
   - Type friction, TDD + typing, commit hygiene
+
+- [Design Language](./language.md)
+  - Visual system, color philosophy, structural primitives
+  - Palette candidates, template conventions, self-check criteria

--- a/doc/design/language.md
+++ b/doc/design/language.md
@@ -1,0 +1,313 @@
+# depo — Design Language
+
+Purpose: define what must remain true as depo evolves,
+while clearly marking what is intentionally unresolved and
+must be learned through use.
+
+## Core description
+
+**Depo** is a simple ingest service:
+content goes in, a short reference comes out.
+
+The reference is the primary object users interact with.
+Everything else
+(aliases, tags, versions, metadata, discovery) is a lens on that reference.
+
+The default workflow is intentionally trivial:
+record content -> receive reference -> use reference anywhere.
+
+**Key constant:** everything in depo is built around a simple reference.
+This should be true in UX, language, visuals, and system behavior.
+
+## 2. Guardrails
+
+These are design constraints, not feature limitations.
+
+Depo is not a file manager, not a folder hierarchy, not a social platform,
+not an opinionated workflow tool, not an organizer by default.
+
+Complexity exists, but it is optional, discoverable,
+and never blocks the core workflow.
+
+## Design philosophy
+
+### Progressive complexity (UNIX-inspired)
+
+Start with the simplest possible action.
+Reveal complexity only when necessary.
+Never force users to understand system internals.
+Avoid creeping complexity at all costs.
+The system may be powerful; the interface must remain calm.
+
+### Old computing constraints as modern restraints
+
+Early systems were constrained by
+limited color, low resolution, and minimal affordances.
+Those constraints enforced clarity and discipline.
+
+Depo deliberately reuses these constraints as design discipline,
+not aesthetic cosplay.
+Sources of inspiration include early Macintosh bitmap patterns,
+Susan Kare-era fills, and terminal TUI conventions
+(box-drawing characters, cell-based alignment, block focus indicators).
+
+## Language principles
+
+### Reference-first language
+
+Prefer showing references over naming "things."
+Names, labels, aliases are conveniences, not identities.
+Avoid metaphors that imply mutability of content.
+
+### Provisional vocabulary (explicitly unresolved)
+
+Core noun (Item / Thing / Deposit / none) is intentionally unsettled.
+Some verbs exist in tension: record vs add, resolve vs view.
+
+#### Design rule
+
+UI language may simplify system truth, but must never contradict it.
+This tension is expected to resolve through usage.
+
+## Visual system — structural rules (LOCKED)
+
+### Gray-scale-first structure (non-negotiable)
+
+Layout, hierarchy, grouping, and affordances must work in pure grayscale.
+Color must never be required to understand structure.
+If removing color breaks the UI, the design is wrong.
+
+Gray-scale handles: spacing, grouping, separation, emphasis via weight (not color).
+
+### Structural tools (before color)
+
+Use these instead of color wherever possible:
+
+#### Spacing
+
+Primary hierarchy via vertical rhythm,
+generous white-space between groups.
+
+#### Typography
+
+Mono-space for references and system identifiers,
+sans/neutral face for prose and labels.
+
+#### Weight
+
+Bold for primary elements, regular/light for metadata.
+
+#### Sizing
+
+Fewer size steps, clearly separated, avoid micro-hierarchies.
+
+#### Dither patterns
+
+1-bit bitmap fills (diagonal lines, checkerboards, crosshatch)
+as a grayscale hierarchy primitive.
+Implemented as small repeating SVG or CSS background patterns.
+Used for separators, section fills, secondary surfaces.
+
+#### TUI elements
+
+Box-drawing characters for borders,
+cell-based alignment, visible hard borders instead of shadows and gradients,
+block-style focus indicators.
+
+#### Shadows
+
+Expressed as hard-edged dither pattern offsets for element hierarchy,
+not CSS blur shadows. No gradients.
+
+Color is a last resort, not a layout tool.
+
+## Color philosophy (LOCKED)
+
+### Color is semantic, not decorative
+
+Every color must answer a specific question.
+No "accent color" without meaning. No branding via color.
+No expressive surfaces or gradients.
+
+### Warm vs cool rule (core invariant)
+
+Cool hues -> system state, stability, focus.
+Warm hues -> attention, interruption.
+Red -> failure only.
+
+This rule holds regardless of palette choice.
+
+### Light / dark mode parity
+
+Light/dark mode changes polarity, not meaning.
+Hue identity must remain consistent. Only luminance and contrast may change.
+
+## Semantic color roles
+
+These roles are stable even if hues change.
+
+| Role | Meaning |
+|------|---------|
+| Structure | Grayscale |
+| Success / Recorded | Stable reference exists |
+| Attention | Salience; pause and notice |
+| Error / Invalid | Failure states only |
+| Secondary info | Quiet, optional emphasis |
+| Focus | What you are currently working with (may be structural) |
+
+## Candidate Palettes
+
+Starting with Palette B.
+Palette A is the fallback if B doesn't hold up
+under real usage and fatigue testing.
+Final decision deferred to lived experience.
+
+### Palette A — Classic Retro (orthodox, conservative)
+
+Background (light):     RGB(245, 245, 245)
+Background (dark):      RGB(24, 24, 24)
+
+Text (primary):         RGB(32, 32, 32)
+Text (secondary):       RGB(110, 110, 110)
+
+Focus / Primary:        RGB(70, 110, 160)     muted blue
+Success / Recorded:     RGB(90, 145, 95)      restrained green
+Attention (info):       RGB(200, 185, 90)     yellow
+Attention (pause):      RGB(200, 140, 60)     amber
+Error / Invalid:        RGB(165, 60, 55)      deep red
+
+Strengths: extremely familiar, lowest cognitive load, lowest risk.
+Green-for-success is deeply ingrained. Users won't notice the palette — it just works.
+
+Weaknesses: safe to the point of generic. Less distinctive personality.
+
+```txt
+Background (light):     RGB(242, 242, 240)
+Background (dark):      RGB(26, 28, 30)
+
+Text (primary):         RGB(36, 38, 40)
+Text (secondary):       RGB(120, 125, 130)
+
+Focus / Primary:        RGB(120, 130, 160)    muted blue-violet
+Success / Recorded:     RGB(85, 145, 135)     desaturated teal
+Attention (info):       RGB(195, 185, 105)    soft yellow
+Attention (pause):      RGB(205, 135, 70)     amber/orange
+Error / Invalid:        RGB(160, 70, 65)      oxide red
+```
+
+### Palette B — Rotated Legacy (starting choice)
+
+```txt
+Background (light):     RGB(242, 242, 240)
+Background (dark):      RGB(26, 28, 30)
+
+Text (primary):         RGB(36, 38, 40)
+Text (secondary):       RGB(120, 125, 130)
+
+Focus / Primary:        RGB(120, 130, 160)    muted blue-violet
+Success / Recorded:     RGB(85, 145, 135)     desaturated teal
+Attention (info):       RGB(195, 185, 105)    soft yellow
+Attention (pause):      RGB(205, 135, 70)     amber/orange
+Error / Invalid:        RGB(160, 70, 65)      oxide red
+```
+
+Strengths: more appliance-like, less "web app." Teal success feels calmer
+and less brand-forward than green. Slightly warmer background grays give
+subtle character without drawing attention. Mac + PlayStation lineage —
+familiar but rotated enough to feel distinct.
+
+Weaknesses: teal-for-success is less conventional — some users may not
+immediately read it as positive. Needs fatigue testing to confirm the
+shifted hues remain comfortable over extended use.
+
+## Color usage rules
+
+Color is foreground-only by default.
+Large surfaces remain grayscale.
+Any color must tolerate accidental overuse.
+If a color draws attention to itself, it is too strong.
+Red is rare and sacred.
+
+## 10. Explicit tensions (INTENTIONAL)
+
+These are not mistakes — they are acknowledged uncertainties.
+
+### Attention vs Secondary
+
+Mutability is architecturally important but usually safe.
+Over-signaling mutability risks alarming users.
+Under-signaling risks confusion later.
+Boundary intentionally unresolved, to be refined through real usage.
+
+### Success hue
+
+### Green vs teal
+
+Teal selected for v1 (Palette B). Offers a rotated legacy
+that feels calmer and less brand-like. May revisit after fatigue testing.
+
+### Focus color
+
+May be expressed structurally (underline, border).
+Focus color may exist but is not required for v1. Deferred.
+
+### Yellow vs amber ladder
+
+Yellow for informational attention, amber for decision-worthy attention.
+May collapse to a single hue initially.
+
+## CSS foundation
+
+### Framework
+
+Pico CSS (classless/semantic).
+Earns its place by providing solid defaults with no build step.
+Custom properties overridden with Palette B values.
+
+### Evaluation
+
+If Pico's defaults are fought more than used, Tailwind earns its seat.
+Tailwind would add a build step — only justified when UI complexity demands it.
+Currently mapped to Pico CSS custom properties in static/css/depo.css.
+
+### HTMX
+
+Bundled locally, no CDN.
+Scripts loaded at bottom of body.
+
+Everything served comes from the deployed host.
+
+## Template conventions
+
+All templates have boundary markers for debugging and testing:
+
+```html
+<!-- BEGIN: template-name.html -->
+<!-- END: template-name.html -->
+```
+
+Full pages extend `base.html`.
+Partials/fragments are standalone (no layout wrapper).
+HTMX requests receive fragments;
+full page loads receive wrapped templates.
+
+Shortcodes displayed with `<code class="shortcode">`;
+functional class, tested against.
+
+## How to evolve this document
+
+Design decisions are categorized as:
+
+- **Locked** — must not change casually
+- **Experimental** — intentionally unresolved
+- **Deferred** — not required for v1
+
+Experience, not theory, resolves tension.
+
+## Self-check
+
+If depo ever feels expressive, clever, brand-forward, or visually loud;
+something has gone wrong.
+
+If it feels calm, boring (in a good way),
+and trustworthy after hours of use, it's working.

--- a/doc/module/web.md
+++ b/doc/module/web.md
@@ -15,27 +15,70 @@ app_factory(config: DepoConfig) -> FastAPI
 Creates FastAPI instance, initializes DB and storage,
 wires repo/storage/orchestrator onto `app.state`.
 Includes route handlers via `APIRouter`.
-
+Mounts static files from `src/depo/static/`.
 SQLite uses `check_same_thread=False` for async handler compatibility.
 
 ## routes.py
 
-Thin route definitions. Maps URLs to handler functions.
+Route definitions for API and browser layers.
+TODO: Split into per-concern routers (near post-MVP).
 
 ### Routes
 
 | Method | Path | Handler | Description |
 |--------|------|---------|-------------|
-| POST | `/api/upload` | `upload()` | Canonical upload endpoint |
-| POST | `/upload` | `upload()` | Shortcut alias |
-| POST | `/` | `upload()` | Shortcut alias |
-| GET | `/api/{code}/raw` | `get_raw()` | Raw content with correct MIME |
-| GET | `/api/{code}/info` | `get_info()` | Key=value metadata |
+| GET | `/` | `root_redirect()` | 302 redirect to `/upload` |
+| GET | `/upload` | `upload_page()` | Serves upload form (HTML) |
+| POST | `/upload` | `upload_form()` | Browser form upload (HTMX) |
+| POST | `/api/upload` | `upload()` | API upload (multipart/raw/URL) |
+| POST | `/` | `upload()` | API upload shortcut |
 | GET | `/health` | `health()` | Liveness probe |
+| GET | `/api/{code}/info` | `get_info()` | Key=value metadata (plain text) |
+| GET | `/api/{code}/raw` | `get_raw()` | Raw content with correct MIME |
+| GET | `/{code}/info` | `info_page()` | HTML info view (per-type template) |
+| GET | `/{code}` | `shortcut()` | Negotiate → redirect to canonical |
 
-Upload handler delegates to `execute_upload()` in upload.py.
-Read handlers use `selector.get_item()` and `selector.get_raw()`.
-LinkItem raw requests return 307 redirect.
+Route ordering matters: specific paths before wildcards.
+`/{code}` and `/{code}/info` must be last to avoid shadowing:
+/health`,`/upload`, etc.
+
+### Shortcut routing
+
+`GET /{code}` uses `wants_html()` to detect client type:
+
+- Browser (`Accept: text/html`) → 302 to `/{code}/info`
+- API client (`Accept: */*` or absent) → 302 to `/api/{code}/raw`
+
+No DB lookup on shortcut — canonical routes handle validation/404.
+
+### Upload handlers
+
+Two separate handlers for different input shapes:
+
+**`upload()` — API path:**
+Handles multipart file, raw body, URL param.
+Delegates to `ingest_upload()`, returns `PlainTextResponse`.
+
+**`upload_form()` — Browser path:**
+Handles textarea content + format override from HTML form.
+Delegates to `parse_form_upload()`, returns HTMX partials.
+
+### Info page dispatch
+
+`info_page()` dispatches to per-type templates based on item kind:
+
+- `TextItem` → `info/text.html` (inline content + metadata)
+- `PicItem` → `info/pic.html` (image display + metadata)
+- `LinkItem` → `info/link.html` (clickable URL + metadata)
+- Unknown kind → 500 (unexpected state)
+- `NotFoundError` → 404
+
+### Error helpers
+
+```python
+_response_404(req, code, e) -> Response   # Styled 404 page
+_response_500(req, detail) -> Response     # 500 with debug context
+```
 
 ## upload.py
 
@@ -56,23 +99,38 @@ class UploadRawBodyParams(TypedDict):
     payload_bytes: bytes
     declared_mime: str
 
-UploadParams = UploadMultipartParams | UploadUrlParams | UploadRawBodyParams
+class UploadFormParams(TypedDict):
+    payload_bytes: bytes
+    declared_mime: str
+    requested_format: ContentFormat | None
+
+UploadParams = UploadMultipartParams | UploadUrlParams | UploadRawBodyParams | UploadFormParams
 ```
 
 Algebraic union — each variant corresponds to an upload path.
+`UploadFormParams` added in PR 9 for browser form submissions.
 
-### upload.py - functions
+### Functions
 
 ```python
 async def parse_upload(file, url, request) -> UploadParams
 ```
 
-Extracts orchestrator kwargs from HTTP request. Branches:
+Extracts orchestrator kwargs from API HTTP request. Branches:
 
 - `file` present → `UploadMultipartParams`
 - `url` present → `UploadUrlParams`
 - Raw body detected as URL → `UploadUrlParams`
 - Raw body otherwise → `UploadRawBodyParams`
+
+```python
+async def parse_form_upload(request) -> UploadFormParams
+```
+
+Extracts orchestrator kwargs from browser form submission.
+Reads `content` (textarea) and `format` (select) from form data.
+Empty/whitespace content raises `ValueError`.
+Non-empty format string converted to `ContentFormat` enum.
 
 ```python
 def upload_response(result: PersistResult) -> PlainTextResponse
@@ -83,10 +141,12 @@ Builds response with short code body and
 201 for new, 200 for dedupe.
 
 ```python
-async def execute_upload(file, url, request, orchestrator) -> PlainTextResponse
+async def ingest_upload(file, url, request, orchestrator) -> PersistResult
 ```
 
-Glue: parse → ingest → respond. Catches `ValueError` → 400.
+Parse API request and ingest. Returns `PersistResult`.
+Raises `ValueError`, `ImportError`, or `PayloadTooLargeError` on failure.
+Replaces former `execute_upload()` — response formatting moved to route handlers.
 
 ### Helper
 
@@ -96,11 +156,38 @@ _looks_like_url(data: bytes) -> bool
 
 Naive URL detection via regex. TODO: Move to ingestion pipeline.
 
+## negotiate.py
+
+Content negotiation utilities.
+
+```python
+def wants_html(request: Request) -> bool
+```
+
+Checks if `text/html` appears in the `Accept` header.
+Browsers always include it; curl and API clients do not.
+Used by shortcut route to dispatch to canonical endpoint.
+
+## templates.py
+
+Template rendering utilities.
+
+```python
+def get_templates() -> Jinja2Templates
+```
+
+Returns `Jinja2Templates` instance pointing at `src/depo/templates/`.
+
+```python
+def is_htmx(request: Request) -> bool
+```
+
+Checks for `HX-Request` header. Used to decide between
+full page response and HTMX fragment/partial.
+
 ## deps.py
 
 FastAPI dependency providers via `Depends()`.
-
-### deps.py - functions
 
 ```python
 get_repo(request) -> SqliteRepository
@@ -109,3 +196,103 @@ get_orchestrator(request) -> IngestOrchestrator
 ```
 
 Thin getters pulling from `request.app.state`.
+
+## Templates
+
+### Structure
+
+```txt
+templates/
+├── base.html                # Full page layout wrapper
+├── upload.html              # Upload form (extends base.html)
+├── info/
+│   ├── text.html            # TextItem info view
+│   ├── pic.html             # PicItem info view
+│   └── link.html            # LinkItem info view
+├── partials/
+│   ├── success.html         # Upload success (HTMX fragment)
+│   └── error.html           # Validation error (HTMX fragment)
+└── errors/
+    ├── 404.html             # Not found page
+    └── 500.html             # Internal error with debug context
+```
+
+### Conventions
+
+**Template markers** — every template has boundary comments for debugging and testing:
+
+```html
+<!-- BEGIN: template-name.html -->
+...
+<!-- END: template-name.html -->
+```
+
+Child templates note their relationship:
+
+```html
+<!-- BEGIN: upload.html -->
+<!-- EXTENDS: base.html -->
+```
+
+Fragments note their role:
+
+```html
+<!-- BEGIN: partials/success.html (fragment) -->
+```
+
+#### Full pages
+
+Extend `base.html` and fill `{% block content %}`.
+Markers must be inside the block
+(Jinja2 discards content outside blocks in child templates).
+
+#### Partials/fragments
+
+Standalone — no extends, no base layout.
+Returned directly for HTMX requests (`HX-Request` header present).
+
+**Shortcode display** uses `<code class="shortcode">` as a project-wide convention.
+The `shortcode` class is functional (tested against), not purely visual.
+
+## HTMX Patterns
+
+### Upload flow
+
+1. Form at `/upload` has `hx-post="/upload"`, `hx-target="#result"`, `hx-swap="innerHTML"`
+2. User submits → `upload_form()` processes
+3. Success → `partials/success.html` swapped into `#result` (shortcode + info link)
+4. Error → `partials/error.html` swapped into `#result` (error message)
+5. User stays on form, ready for next upload (multi-upload workflow)
+
+### Request detection
+
+`is_htmx(request)` checks `HX-Request` header.
+Currently used implicitly by `upload_form()` always returning partials.
+Future: may need full-page fallback for non-JS browsers.
+
+## Static Assets
+
+Bundled locally, served via FastAPI `StaticFiles` mount at `/static`.
+
+```txt
+static/
+├── css/
+│   ├── pico.min.css         # Pico CSS framework
+│   └── depo.css             # Palette B custom property overrides
+└── js/
+    └── htmx.min.js          # HTMX library
+```
+
+Everything served comes from the deployed host — no CDN dependencies.
+
+## Error Handling
+
+| Error | API Response | Browser Response |
+|-------|-------------|------------------|
+| `ValueError` | 400 plain text | Error partial |
+| `PayloadTooLargeError` | 413 plain text | Error partial (413) |
+| `ImportError` | 501 plain text | Error partial |
+| `NotFoundError` | 404 plain text | Styled 404 page |
+| Unexpected state | — | 500 with debug context |
+
+`PayloadTooLargeError` must be caught before `ValueError` (it inherits from it).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.12"
 dependencies = [
     "click>=8.3.1",
     "fastapi>=0.128.5",
+    "jinja2>=3.1.6",
     "pillow>=12.1.0",
     "python-multipart>=0.0.22",
     "rich>=14.3.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dev-dependencies = [
   "pytest-xdist",
   "httpx>=0.28.1",
   "pytest-asyncio>=1.3.0",
+  "beautifulsoup4>=4.14.3",
 ]
 
 [tool.pytest]

--- a/src/depo/service/ingest.py
+++ b/src/depo/service/ingest.py
@@ -17,6 +17,7 @@ from depo.model.enums import ContentFormat, ItemKind, PayloadKind
 from depo.model.write_plan import WritePlan
 from depo.service.classify import classify
 from depo.service.media import get_image_info
+from depo.util.errors import PayloadTooLargeError
 from depo.util.shortcode import hash_full_b32
 
 
@@ -115,7 +116,7 @@ class IngestService:
         size = len(data)
         if size > self.max_size_bytes:
             msg = f"Payload size {size} bytes exceeds limit {self.max_size_bytes}"
-            raise ValueError(msg)
+            raise PayloadTooLargeError(msg)
         if size <= 0:
             raise ValueError("Payload is empty")
 

--- a/src/depo/static/css/depo.css
+++ b/src/depo/static/css/depo.css
@@ -1,0 +1,12 @@
+/* src/depo/static/css/depo.css */
+/* Override Pico CSS custom properties with Palette B (Rotated Legacy) */
+/* Background light: rgb(242, 242, 240) */
+/* Background dark:  rgb(26, 28, 30) */
+/* Text primary:     rgb(36, 38, 40) */
+/* Text secondary:   rgb(120, 125, 130) */
+/* Focus/Primary:    rgb(120, 130, 160) */
+/* Success/Recorded: rgb(85, 145, 135) */
+/* Attention info:   rgb(195, 185, 105) */
+/* Attention pause:  rgb(205, 135, 70) */
+/* Error/Invalid:    rgb(160, 70, 65) */
+/* Monospace for references and system identifiers */

--- a/src/depo/static/css/pico.min.css
+++ b/src/depo/static/css/pico.min.css
@@ -1,0 +1,1 @@
+Redirecting to /@picocss/pico@2.1.1/css/pico.min.css

--- a/src/depo/static/js/htmx.min.js
+++ b/src/depo/static/js/htmx.min.js
@@ -1,0 +1,1 @@
+Redirecting to /htmx.org@2.0.8/dist/htmx.min.js

--- a/src/depo/templates/base.html
+++ b/src/depo/templates/base.html
@@ -1,4 +1,19 @@
-<!-- src/depo/templates/base.html -->
+<!-- BEGIN: base.html -->
 <!-- Full page layout wrapper -->
-<!-- Head: load /static/css/pico.min.css, /static/css/depo.css, /static/js/htmx.min.js -->
-<!-- Body: define {% block content %}{% endblock %} -->
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% block title %}depo{% endblock %}</title>
+    <link rel="stylesheet" href="/static/css/pico.min.css">
+    <link rel="stylesheet" href="/static/css/depo.css">
+    <script defer src="/static/js/htmx.min.js"></script>
+  </head>
+  <body>
+    <main>
+      {% block content %}
+      {% endblock %}
+    </main>
+  </body>
+</html>
+<!-- END: base.html -->

--- a/src/depo/templates/base.html
+++ b/src/depo/templates/base.html
@@ -1,0 +1,4 @@
+<!-- src/depo/templates/base.html -->
+<!-- Full page layout wrapper -->
+<!-- Head: load /static/css/pico.min.css, /static/css/depo.css, /static/js/htmx.min.js -->
+<!-- Body: define {% block content %}{% endblock %} -->

--- a/src/depo/templates/errors/404.html
+++ b/src/depo/templates/errors/404.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% block content %}
+<!-- BEGIN: errors/404.html -->
+<h2>Not found!</h2>
+</p>The shortcode </p>
+<code class="shortcode">{{ code | upper }}</code>
+<p> does not exist or was deleted.</p>
+<!-- END: errors/404.html -->
+{% endblock %}

--- a/src/depo/templates/errors/500.html
+++ b/src/depo/templates/errors/500.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+{% block content %}
+<!-- BEGIN: errors/500.html -->
+<h2>{{ message }}</h2>
+<p>An unexpected error occurred. If this persists, please
+  <a href="{{ issues_url }}">report it</a>.
+</p>
+<details>
+  <summary>Debug info</summary>
+  <dl>
+    <dt>Path</dt><dd>{{ path }}</dd>
+    <dt>Method</dt><dd>{{ method }}</dd>
+    <dt>Detail</dt><dd>{{ detail }}</dd>
+  </dl>
+</details>
+<!-- END: errors/500.html -->
+{% endblock %}

--- a/src/depo/templates/info/link.html
+++ b/src/depo/templates/info/link.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+{% block content %}
+<!-- BEGIN: info/link.html -->
+<code class="shortcode">{{ item.code | upper }}</code>
+<dl>
+  <dt>URL</dt><dd><a href="{{ item.url }}">{{ item.url }}</a></dd>
+  <dt>Uploaded</dt><dd>{{ item.upload_at }}</dd>
+</dl>
+<!-- END: info/link.html -->
+{% endblock %}

--- a/src/depo/templates/info/pic.html
+++ b/src/depo/templates/info/pic.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+{% block content %}
+<!-- BEGIN: info/pic.html (extends base.html) -->
+<code class="shortcode">{{ item.code | upper }}</code>
+<dl>
+  <dt>Format</dt><dd>{{ item.format }}</dd>
+  <dt>Size</dt><dd>{{ item.size_b }} bytes</dd>
+  <dt>Dimensions</dt><dd>{{item.width}}x{{item.height}}</dd>
+  <dt>Uploaded</dt><dd>{{ item.upload_at }}</dd>
+</dl>
+<div class="content__container--pic">
+  <img src="/api/{{ item.code }}/raw">
+</div>
+<!-- END: info/pic.html -->
+{% endblock %}

--- a/src/depo/templates/info/text.html
+++ b/src/depo/templates/info/text.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+{% block content %}
+<!-- BEGIN: info/text.html (extends base.html) -->
+<!-- Rendered text content + metadata -->
+<code class="shortcode">{{ item.code | upper }}</code>
+<dl>
+  <dt>Format</dt><dd>{{ item.format }}</dd>
+  <dt>Size</dt><dd>{{ item.size_b }} bytes</dd>
+  <dt>Uploaded</dt><dd>{{ item.upload_at }}</dd>
+</dl>
+<pre class="content__container--text">
+  <code>{{ content }}</code>
+</pre>
+<!-- END: info/text.html -->
+{% endblock %}

--- a/src/depo/templates/partials/error.html
+++ b/src/depo/templates/partials/error.html
@@ -1,0 +1,5 @@
+<!-- BEGIN: partials/error.html (fragment) -->
+<div class="upload-error" role="alert">
+  <p>{{ error }}</p>
+</div>
+<!-- END: partials/error.html -->

--- a/src/depo/templates/partials/success.html
+++ b/src/depo/templates/partials/success.html
@@ -1,0 +1,6 @@
+<!-- BEGIN: partials/success.html (fragment) -->
+<div class="upload-result">
+  <code class="shortcode">{{ code }}</code>
+  <a href="/{{ code }}/info">View info</a>
+</div>
+<!-- END: partials/success.html -->

--- a/src/depo/templates/upload.html
+++ b/src/depo/templates/upload.html
@@ -2,7 +2,13 @@
 <!-- EXTENDS: base.html -->
 {% extends "base.html" %}
 {% block content %}
-<form method="post" action="/upload">
+<form
+    method="post"
+    action="/upload"
+    hx-post="/upload"
+    hx-target="#result"
+    hx-swap="innerHTML"
+  >
   <textarea name="content">
   </textarea>
   <select name="format">
@@ -22,6 +28,7 @@
   </select>
   <button type="submit">Record</button>
 </form>
+<div id="result"></div>
 <!-- Form: textarea for content, select dropdown for type override, submit button -->
 <!-- Form will use hx-post in next commit, plain POST action for now -->
 <!-- END: upload.html -->

--- a/src/depo/templates/upload.html
+++ b/src/depo/templates/upload.html
@@ -1,0 +1,28 @@
+<!-- BEGIN: upload.html -->
+<!-- EXTENDS: base.html -->
+{% extends "base.html" %}
+{% block content %}
+<form method="post" action="/upload">
+  <textarea name="content">
+  </textarea>
+  <select name="format">
+    <option value="" selected>Auto-detect</option>
+    <optgroup label="Text">
+      <option value="txt">Plain Text</option>
+      <option value="md">Markdown</option>
+      <option value="json">JSON</option>
+      <option value="yaml">YAML</option>
+    </optgroup>
+    <optgroup label="Image">
+      <option value="jpg">JPEG</option>
+      <option value="png">PNG</option>
+      <option value="webp">WebP</option>
+      <option value="tiff">TIFF</option>
+    </optgroup>
+  </select>
+  <button type="submit">Record</button>
+</form>
+<!-- Form: textarea for content, select dropdown for type override, submit button -->
+<!-- Form will use hx-post in next commit, plain POST action for now -->
+<!-- END: upload.html -->
+{% endblock %}

--- a/src/depo/util/errors.py
+++ b/src/depo/util/errors.py
@@ -1,0 +1,13 @@
+# src/depo/util/errors.py
+"""
+Central error types for depo.
+Author: Marcus Grant
+Created: 2026-02-12
+License: Apache-2.0
+"""
+
+
+class PayloadTooLargeError(ValueError):
+    """Payload exceeds maximum allowed size."""
+
+    pass

--- a/src/depo/web/app.py
+++ b/src/depo/web/app.py
@@ -10,8 +10,10 @@ License: Apache-2.0
 """
 
 import sqlite3
+from pathlib import Path
 
 from fastapi import FastAPI
+from starlette.staticfiles import StaticFiles
 
 from depo.cli.config import DepoConfig
 from depo.repo.sqlite import SqliteRepository, init_db
@@ -48,4 +50,8 @@ def app_factory(config: DepoConfig) -> FastAPI:
 
     # Store the router for FastAPI
     app.include_router(router)
+
+    # Mount static assets directory for frontend - must come AFTER routes
+    static_dir = Path(__file__).parent.parent / "static"
+    app.mount("/static", StaticFiles(directory=static_dir), name="static")
     return app  # Return FastAPI app

--- a/src/depo/web/negotiate.py
+++ b/src/depo/web/negotiate.py
@@ -1,0 +1,18 @@
+# src/depo/web/negotiate.py
+"""
+Content negotiation utilities.
+Determines client type from Accept header to dispatch
+shortcut routes to the correct canonical endpoint.
+Author: Marcus Grant
+Created: 2026-02-12
+License: Apache-2.0
+"""
+
+from starlette.requests import Request
+
+
+def wants_html(request: Request) -> bool:
+    """Does the client prefer an HTML response (browser vs API/CLI)?"""
+    if "text/html" in request.headers.get("Accept", ""):
+        return True
+    return False

--- a/src/depo/web/routes.py
+++ b/src/depo/web/routes.py
@@ -23,15 +23,22 @@ from depo.repo.sqlite import SqliteRepository
 from depo.service.orchestrator import IngestOrchestrator
 from depo.storage.protocol import StorageBackend
 from depo.web.deps import get_orchestrator, get_repo, get_storage
+from depo.web.templates import get_templates
 from depo.web.upload import execute_upload
 
 router = APIRouter()
 
 
-@router.get("/health")
-def health() -> PlainTextResponse:
-    """Return plain text health check for liveness probes."""
-    return PlainTextResponse(content="ok", status_code=200)
+@router.get("/")
+async def root_redirect():
+    """Redirect root to canonical upload page."""
+    return RedirectResponse(url="/upload", status_code=302)
+
+
+@router.get("/upload")
+async def upload_page(req: Request):
+    """Serve the upload form as a full HTML page."""
+    return get_templates().TemplateResponse(request=req, name="upload.html")
 
 
 @router.post("/api/upload", status_code=201)
@@ -49,6 +56,12 @@ async def upload(
     if url is not None:
         return await execute_upload(None, url, None, orch)
     return await execute_upload(None, None, req, orch)
+
+
+@router.get("/health")
+def health() -> PlainTextResponse:
+    """Return plain text health check for liveness probes."""
+    return PlainTextResponse(content="ok", status_code=200)
 
 
 @router.get("/api/{code}/info")

--- a/src/depo/web/templates.py
+++ b/src/depo/web/templates.py
@@ -1,0 +1,24 @@
+# src/depo/web/templates.py
+"""
+Template rendering utilities.
+Jinja2 setup and HTMX-aware response helpers.
+Author: Marcus Grant
+Created: 2026-02-12
+License: Apache-2.0
+"""
+
+from pathlib import Path
+
+from starlette.requests import Request
+from starlette.templating import Jinja2Templates
+
+
+def is_htmx(request: Request) -> bool:
+    """Check if request originated from HTMX (HX-Request header)."""
+    return request.headers.get("HX-Request") == "true"
+
+
+def get_templates() -> Jinja2Templates:
+    """Build Jinja2Templates instance pointing at the templates directory."""
+    path = Path(__file__).parent.parent / "templates"
+    return Jinja2Templates(directory=path)

--- a/tests/factories/web.py
+++ b/tests/factories/web.py
@@ -10,8 +10,11 @@ Created: 2026-02-09
 License: Apache-2.0
 """
 
+from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 
+from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
 
 from depo.web.app import app_factory
@@ -21,3 +24,18 @@ from tests.factories.config import make_config
 def make_client(p: Path) -> TestClient:
     """Build a TestClient from a DepoConfig pointing at tmp_path."""
     return TestClient(app_factory(make_config(p)))
+
+
+def make_probe_client(probe_fn: Callable[[Request], Any]) -> TestClient:
+    """Build a minimal test app with a single GET /probe route.
+    probe_fn receives the Request, its return value becomes the response.
+    """
+    app = FastAPI()
+
+    @app.get("/probe")
+    def _probe(request: Request):
+        return probe_fn(request)
+
+    _ = _probe  # satisfy linters
+
+    return TestClient(app)

--- a/tests/web/test_errors.py
+++ b/tests/web/test_errors.py
@@ -1,0 +1,124 @@
+# tests/web/test_errors.py
+"""
+Tests for error handlers.
+Author: Marcus Grant
+Created: 2026-02-16
+License: Apache-2.0
+"""
+
+from bs4 import BeautifulSoup
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+from tests.factories.web import make_client
+
+
+class TestError404Page:
+    """404 error page rendering"""
+
+    def test_response(self, tmp_path):
+        """404 page renders with code and base template."""
+        client = make_client(tmp_path)
+        resp = client.get("/ZZZZZZZZ/info")
+        assert resp.status_code == 404
+        assert "<!-- BEGIN: base.html" in resp.text
+        assert "<!-- BEGIN: errors/404.html" in resp.text
+        assert "ZZZZZZZZ" in resp.text
+
+
+class TestError413Page:
+    """413 payload too large error"""
+
+    def test_api_oversized_returns_413(self, tmp_path):
+        """API upload exceeding max size returns 413."""
+        client = make_client(tmp_path)
+        payload = b"x" * (2**20 + 1)
+        resp = client.post("/api/upload", files={"file": ("big.txt", payload)})
+        assert resp.status_code == 413
+
+    def test_htmx_oversized_returns_413(self, tmp_path):
+        """HTMX upload exceeding max size returns error partial."""
+        client = make_client(tmp_path)
+        content = "x" * (2**20 + 1)
+        resp = client.post(
+            "/upload",
+            data={"content": content, "format": ""},
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 413
+        assert "<!-- BEGIN: partials/error.html" in resp.text
+
+
+class TestHtmxErrorPartial:
+    """HTMX requests receive error partials, not full pages"""
+
+    def test_error_partial_no_base_template(self, tmp_path):
+        """HTMX error response is a fragment, not wrapped in base.html."""
+        client = make_client(tmp_path)
+        resp = client.post(
+            "/upload",
+            data={"content": "", "format": ""},
+            headers={"HX-Request": "true"},
+        )
+        assert "<!-- BEGIN: partials/error.html" in resp.text
+        assert "<!-- BEGIN: base.html" not in resp.text
+
+    def test_error_partial_contains_message(self, tmp_path):
+        """HTMX error partial includes the error message."""
+        client = make_client(tmp_path)
+        resp = client.post(
+            "/upload",
+            data={"content": "", "format": ""},
+            headers={"HX-Request": "true"},
+        )
+        assert "No content provided" in resp.text
+
+    def test_413_partial_no_base_template(self, tmp_path):
+        """HTMX 413 error is a fragment, not wrapped in base.html."""
+        client = make_client(tmp_path)
+        content = "x" * (2**20 + 1)
+        resp = client.post(
+            "/upload",
+            data={"content": content, "format": ""},
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 413
+        assert "<!-- BEGIN: partials/error.html" in resp.text
+        assert "<!-- BEGIN: base.html" not in resp.text
+
+
+class TestError500Page:
+    """500 internal server error rendering"""
+
+    def _make_500_client(self) -> TestClient:
+        from depo.web.routes import _response_500
+
+        app = FastAPI()
+
+        @app.get("/trigger500")
+        def _trigger(request: Request):
+            return _response_500(request, "test error detail")
+
+        _ = _trigger
+        return TestClient(app)
+
+    def test_response(self):
+        """500 page renders with debug context and issues link."""
+        resp = self._make_500_client().get("/trigger500")
+        assert resp.status_code == 500
+        soup = BeautifulSoup(resp.text, "html.parser")
+        assert "<!-- BEGIN: base.html" in resp.text
+        assert "<!-- BEGIN: errors/500.html" in resp.text
+        assert "Something went wrong" in resp.text
+        assert "test error detail" in resp.text
+        href = "https://github.com/marcus-grant/depo/issues"
+        assert soup.find("a", href=(href is not None))
+
+    def test_debug_info_present(self):
+        """Debug info contains path and method."""
+        resp = self._make_500_client().get("/trigger500")
+        soup = BeautifulSoup(resp.text, "html.parser")
+        details = soup.find("details")
+        assert details is not None
+        assert "/trigger500" in details.text
+        assert "GET" in details.text

--- a/tests/web/test_info_page.py
+++ b/tests/web/test_info_page.py
@@ -1,0 +1,107 @@
+# tests/web/test_info_page.py
+"""
+Tests for HTML info views.
+Author: Marcus Grant
+Created: 2026-02-16
+License: Apache-2.0
+"""
+
+from bs4 import BeautifulSoup
+
+from tests.factories.payloads import gen_image
+from tests.factories.web import make_client
+
+
+class TestInfoPageText:
+    """GET /{code}/info for TextItem"""
+
+    def test_response(self, tmp_path):
+        """Text info page returns correct template, shortcode, content, and metadata."""
+        client, file = make_client(tmp_path), {"file": ("hello.txt", b"Hello, World!")}
+        resp = client.post("/api/upload", files=file)
+        assert resp.status_code == 201
+        code = resp.text
+        resp = client.get(f"/{code}/info")
+        msg = "Response is not HTML"
+        assert resp.headers.get("content-type", "").startswith("text/html"), msg
+        assert resp.status_code == 200
+        assert "<!-- BEGIN: info/text.html" in resp.text
+        assert "<!-- END: info/text.html -->" in resp.text
+        assert "<!-- BEGIN: base.html" in resp.text, "Page not wrapped in base template"
+        soup = BeautifulSoup(resp.content, "html.parser")
+        code_el = soup.find(class_="shortcode")
+        dts = {dt.text: dt.find_next_sibling("dd").text for dt in soup.find_all("dt")}  # type: ignore
+        assert code_el is not None
+        assert code in code_el.text
+        assert "Hello, World!" in resp.text
+        assert "Format" in dts
+        assert dts["Format"] == "txt"
+        assert dts["Size"] == "13 bytes"
+        assert "Uploaded" in dts
+
+
+class TestInfoPagePic:
+    """GET /{code}/info for PicItem"""
+
+    def test_response(self, tmp_path):
+        """Text info page returns correct template, shortcode, content, and metadata."""
+        img = gen_image("jpeg", width=64, height=64)
+        client, file = make_client(tmp_path), {"file": ("test.jpg", img)}
+        resp = client.post("/api/upload", files=file)
+        assert resp.status_code == 201, "Failed to assemble test item as upload"
+        code = resp.text
+        resp = client.get(f"/{code}/info")
+        assert resp.status_code == 200
+        assert "<!-- BEGIN: info/pic.html" in resp.text
+        assert "<!-- END: info/pic.html -->" in resp.text
+        assert "<!-- BEGIN: base.html" in resp.text, "Page not wrapped in base template"
+        soup = BeautifulSoup(resp.content, "html.parser")
+        code_el = soup.find(class_="shortcode")
+        dts = {dt.text: dt.find_next_sibling("dd").text for dt in soup.find_all("dt")}  # type: ignore
+        img_el = soup.find("img")
+        assert code_el is not None
+        assert code in code_el.text
+        assert img_el is not None
+        assert f"/api/{code}/raw" in img_el["src"]
+        assert "Format" in dts
+        assert dts["Format"] == "jpg"
+        assert dts["Size"] == f"{len(img)} bytes"
+        assert "Uploaded" in dts
+        assert dts["Dimensions"] == "64x64"
+
+
+class TestInfoPageLink:
+    """GET /{code}/info for LinkItem"""
+
+    def test_response(self, tmp_path):
+        """Link info page returns correct template, shortcode, and clickable URL."""
+        url = "https://example.com"
+        client = make_client(tmp_path)
+        resp = client.post(f"/api/upload?url={url}")
+        assert resp.status_code == 201, "Failed to assemble test item as upload"
+        code = resp.text
+        resp = client.get(f"/{code}/info")
+        assert resp.status_code == 200
+        assert "<!-- BEGIN: info/link.html" in resp.text
+        assert "<!-- END: info/link.html -->" in resp.text
+        assert "<!-- BEGIN: base.html" in resp.text
+        soup = BeautifulSoup(resp.content, "html.parser")
+        code_el = soup.find(class_="shortcode")
+        assert code_el is not None
+        assert code in code_el.text
+        link_el = soup.find("a", href=url)
+        assert link_el is not None
+        assert url in link_el.text
+        dts = {dt.text: dt.find_next_sibling("dd").text for dt in soup.find_all("dt")}  # type: ignore
+        assert "URL" in dts
+        assert "Uploaded" in dts
+
+
+class TestInfoPageNotFound:
+    """GET /{code}/info for unknown code"""
+
+    def test_unknown_code_returns_404(self, tmp_path):
+        """Unknown code returns 404."""
+        client = make_client(tmp_path)
+        resp = client.get("/ZZZZZZZZ/info")
+        assert resp.status_code == 404

--- a/tests/web/test_negotiate.py
+++ b/tests/web/test_negotiate.py
@@ -1,0 +1,40 @@
+# tests/web/test_negotiate.py
+"""
+Tests for content negotiation.
+Author: Marcus Grant
+Created: 2026-02-12
+License: Apache-2.0
+"""
+
+import pytest
+
+from depo.web.negotiate import wants_html
+from tests.factories.web import make_probe_client
+
+
+class TestWantsHtml:
+    """Accept header detection for browser vs API dispatch.
+
+    Uses a minimal test app since no depo routes
+    consume wants_html yet.
+    """
+
+    @pytest.mark.parametrize(
+        "accept_value, expected",
+        [
+            ("text/html", True),
+            ("text/html,application/json", True),
+            ("application/json", False),
+            ("*/*", False),
+        ],
+    )
+    def test_true_for_accept_text_html(self, accept_value, expected):
+        """Accept: text/html -> True (browser)"""
+        client = make_probe_client(lambda r: {"html": wants_html(r)})
+        headers = {"Accept": accept_value}
+        assert client.get("/probe", headers=headers).json()["html"] == expected
+
+    def test_no_accept_header_false(self):
+        """Accept: text/html -> True (browser)"""
+        client = make_probe_client(lambda r: {"html": wants_html(r)})
+        assert not client.get("/probe").json()["html"]

--- a/tests/web/test_negotiate_routes.py
+++ b/tests/web/test_negotiate_routes.py
@@ -1,0 +1,41 @@
+# tests/web/test_negotiate_routes.py
+"""
+Tests for shortcut route negotiation.
+Author: Marcus Grant
+Created: 2026-02-16
+License: Apache-2.0
+"""
+
+import pytest
+
+from tests.factories.web import make_client
+
+
+class TestShortcutRoute:
+    """GET /{code} redirects based on client type"""
+
+    @pytest.mark.parametrize(
+        "accept_head, expected",
+        [
+            ("text/html", "/f00bar/info"),
+            ("*/*", "/api/f00bar/raw"),
+            ("some/format", "/api/f00bar/raw"),
+            ("", "/api/f00bar/raw"),
+        ],
+    )
+    def test_different_client_redirects(self, accept_head, expected, tmp_path):
+        kwargs = {"headers": {"Accept": accept_head}, "follow_redirects": False}
+        resp = make_client(tmp_path).get("/f00bar", **kwargs)
+        assert resp.status_code == 302
+        assert resp.headers["location"] == expected
+
+    def test_unknown_code_redirects(self, tmp_path):
+        """Unknown code still redirects (validation happens at canonical route)."""
+        kwargs = {"headers": {"Accept": "text/html"}, "follow_redirects": False}
+        resp = make_client(tmp_path).get("/N0EX1ST", **kwargs)
+        assert resp.status_code == 302
+        assert resp.headers["location"] == "/N0EX1ST/info"
+        kwargs = {"headers": {"Accept": "*/*"}, "follow_redirects": False}
+        resp = make_client(tmp_path).get("/N0EX1ST", **kwargs)
+        assert resp.status_code == 302
+        assert resp.headers["location"] == "/api/N0EX1ST/raw"

--- a/tests/web/test_routes.py
+++ b/tests/web/test_routes.py
@@ -95,15 +95,6 @@ class TestUploadLink:
 class TestUploadShortcuts:
     """Tests for convenience route aliases."""
 
-    def test_post_upload_alias(self, tmp_path):
-        """POST /upload routes same as /api/upload."""
-        client = make_client(tmp_path)
-        resp = client.post("/upload", files={"file": ("test.txt", b"hello upload")})
-        assert resp.status_code == 201
-        assert resp.headers["X-Depo-Code"] == resp.text
-        assert resp.headers["X-Depo-Kind"] == "txt"
-        assert resp.headers["X-Depo-Created"] == "true"
-
     def test_post_root_alias(self, tmp_path):
         """POST / routes same as /api/upload."""
         client = make_client(tmp_path)

--- a/tests/web/test_static.py
+++ b/tests/web/test_static.py
@@ -1,0 +1,31 @@
+# tests/web/test_static.py
+"""
+Tests for static file serving.
+Verifies bundled frontend assets are accessible.
+Author: Marcus Grant
+Created: 2026-02-12
+License: Apache-2.0
+"""
+
+from tests.factories.web import make_client
+
+
+class TestStaticFiles:
+    """Static assets are served correctly."""
+
+    def test_htmx_served(self, tmp_path):
+        """HTMX JS bundle is accessible."""
+        resp = make_client(tmp_path).get("/static/js/htmx.min.js")
+        assert resp.status_code == 200
+        assert "javascript" in resp.headers["content-type"]
+
+    def test_pico_served(self, tmp_path):
+        """Pico CSS bundle is accessible."""
+        resp = make_client(tmp_path).get("/static/css/pico.min.css")
+        assert resp.status_code == 200
+        assert "css" in resp.headers["content-type"]
+
+    def test_missing_static_404(self, tmp_path):
+        """Non-existent static file returns 404."""
+        resp = make_client(tmp_path).get("/static/nope.js")
+        assert resp.status_code == 404

--- a/tests/web/test_templates.py
+++ b/tests/web/test_templates.py
@@ -8,10 +8,9 @@ License: Apache-2.0
 
 import jinja2
 import pytest
-from fastapi import FastAPI, Request
-from starlette.testclient import TestClient
 
 from depo.web.templates import get_templates, is_htmx
+from tests.factories.web import make_probe_client
 
 
 class TestIsHtmx:
@@ -21,22 +20,13 @@ class TestIsHtmx:
     returns the result of is_htmx() as plain text.
     """
 
-    def _make_app(self) -> TestClient:
-        app = FastAPI()
-
-        @app.get("/probe")
-        def probe(request: Request):
-            return {"htmx": is_htmx(request)}
-
-        return TestClient(app)
-
     def test_true_when_header_present(self):
-        client = self._make_app()
+        client = make_probe_client(lambda r: {"htmx": is_htmx(r)})
         resp = client.get("/probe", headers={"HX-Request": "true"})
         assert resp.json()["htmx"] is True
 
     def test_false_when_header_absent(self):
-        client = self._make_app()
+        client = make_probe_client(lambda r: {"htmx": is_htmx(r)})
         resp = client.get("/probe")
         assert resp.json()["htmx"] is False
 

--- a/tests/web/test_templates.py
+++ b/tests/web/test_templates.py
@@ -1,0 +1,56 @@
+# tests/web/test_templates.py
+"""
+Tests for template rendering utilities.
+Author: Marcus Grant
+Created: 2026-02-12
+License: Apache-2.0
+"""
+
+import jinja2
+import pytest
+from fastapi import FastAPI, Request
+from starlette.testclient import TestClient
+
+from depo.web.templates import get_templates, is_htmx
+
+
+class TestIsHtmx:
+    """HTMX request detection via HX-Request header.
+
+    Uses a minimal test app with a single route that
+    returns the result of is_htmx() as plain text.
+    """
+
+    def _make_app(self) -> TestClient:
+        app = FastAPI()
+
+        @app.get("/probe")
+        def probe(request: Request):
+            return {"htmx": is_htmx(request)}
+
+        return TestClient(app)
+
+    def test_true_when_header_present(self):
+        client = self._make_app()
+        resp = client.get("/probe", headers={"HX-Request": "true"})
+        assert resp.json()["htmx"] is True
+
+    def test_false_when_header_absent(self):
+        client = self._make_app()
+        resp = client.get("/probe")
+        assert resp.json()["htmx"] is False
+
+
+class TestGetTemplates:
+    """Jinja2Templates instance configuration."""
+
+    def test_can_locate_base_template(self):
+        """Returned instance can locate base.html and known templates"""
+        templates = get_templates()
+        assert templates.get_template("base.html")  # Shouldn't raise TemplateNotFound
+
+    def test_missing_template_raises(self):
+        """Unknown template name raises TemplateNotFound."""
+        templates = get_templates()
+        with pytest.raises(jinja2.TemplateNotFound):
+            templates.get_template("nope.html")

--- a/tests/web/test_templates.py
+++ b/tests/web/test_templates.py
@@ -8,6 +8,7 @@ License: Apache-2.0
 
 import jinja2
 import pytest
+from bs4 import BeautifulSoup, Comment
 
 from depo.web.templates import get_templates, is_htmx
 from tests.factories.web import make_probe_client
@@ -44,3 +45,45 @@ class TestGetTemplates:
         templates = get_templates()
         with pytest.raises(jinja2.TemplateNotFound):
             templates.get_template("nope.html")
+
+
+class TestBaseTemplate:
+    """Base layout template renders correctly.
+
+    # Content block renders outside HTML comments
+    # Template markers (BEGIN/END) present
+    # Static asset references present (pico, htmx, depo.css)
+    """
+
+    def _render(self, block_content: str = "") -> str:
+        """Render base.html with a test string in the content block."""
+        env = get_templates().env
+        template = env.from_string(
+            '{% extends "base.html" %}{% block content %}'
+            + block_content
+            + "{% endblock %}"
+        )
+        return template.render()
+
+    def test_content_not_inside_comment(self):
+        """Content block renders as real HTML, not inside a comment."""
+        marker = "TESTBLOCK123"
+        html = self._render(marker)
+        soup = BeautifulSoup(html, "html.parser")
+        # Marker should appear outside any HTML comment
+        assert marker in html
+        for comment in soup.find_all(string=lambda s: isinstance(s, Comment)):
+            assert marker not in comment
+
+    def test_template_markers_present(self):
+        """BEGIN and END markers present."""
+        html = self._render()
+        assert "<!-- BEGIN: base.html -->" in html
+        assert "<!-- END: base.html -->" in html
+
+    def test_static_asset_references(self):
+        """References to bundled CSS and JS present."""
+        html = self._render()
+        assert "pico.min.css" in html
+        assert "depo.css" in html
+        assert "htmx.min.js" in html

--- a/tests/web/test_upload_htmx.py
+++ b/tests/web/test_upload_htmx.py
@@ -1,0 +1,85 @@
+# tests/web/test_upload_htmx.py
+"""
+Tests for HTMX upload flow.
+Author: Marcus Grant
+Created: 2026-02-13
+License: Apache-2.0
+"""
+
+from bs4 import BeautifulSoup
+
+from tests.factories.web import make_client
+
+
+class TestHtmxUploadSuccess:
+    """POST /upload with HX-Request returns success partial"""
+
+    def test_success_returns_shortcode(self, tmp_path):
+        client = make_client(tmp_path)
+        resp = client.post(
+            "/upload",
+            data={"content": "hello world", "format": ""},
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 200
+        soup = BeautifulSoup(resp.text, "html.parser")
+        code_el = soup.find("code", class_="shortcode")
+        assert code_el is not None
+        assert len(code_el.text.strip()) > 0
+
+    def test_success_contains_info_link(self, tmp_path):
+        client = make_client(tmp_path)
+        resp = client.post(
+            "/upload",
+            data={"content": "hello world", "format": ""},
+            headers={"HX-Request": "true"},
+        )
+        soup = BeautifulSoup(resp.text, "html.parser")
+        code = soup.find("code", class_="shortcode").text.strip()  # type: ignore
+        link = soup.find("a", href=f"/{code}/info")
+        assert link is not None
+
+    def test_success_is_fragment(self, tmp_path):
+        client = make_client(tmp_path)
+        resp = client.post(
+            "/upload",
+            data={"content": "hello world", "format": ""},
+            headers={"HX-Request": "true"},
+        )
+        assert "<!-- BEGIN: base.html -->" not in resp.text
+        assert "<!-- BEGIN: partials/success.html" in resp.text
+
+
+class TestHtmxUploadError:
+    """POST /upload with HX-Request returns error partial on failure."""
+
+    def test_empty_content_returns_error(self, tmp_path):
+        client = make_client(tmp_path)
+        resp = client.post(
+            "/upload",
+            data={"content": "", "format": ""},
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 200
+        soup = BeautifulSoup(resp.text, "html.parser")
+        error = soup.find("div", class_="upload-error")
+        assert error is not None
+
+    def test_error_contains_message(self, tmp_path):
+        client = make_client(tmp_path)
+        resp = client.post(
+            "/upload",
+            data={"content": "", "format": ""},
+            headers={"HX-Request": "true"},
+        )
+        assert "No content provided" in resp.text
+
+    def test_error_is_fragment(self, tmp_path):
+        client = make_client(tmp_path)
+        resp = client.post(
+            "/upload",
+            data={"content": "", "format": ""},
+            headers={"HX-Request": "true"},
+        )
+        assert "<!-- BEGIN: base.html -->" not in resp.text
+        assert "<!-- BEGIN: partials/error.html" in resp.text

--- a/tests/web/test_upload_page.py
+++ b/tests/web/test_upload_page.py
@@ -1,0 +1,96 @@
+# tests/web/test_upload_page.py
+"""
+Tests for the upload form page.
+Author: Marcus Grant
+Created: 2026-02-13
+License: Apache-2.0
+"""
+
+from bs4 import BeautifulSoup
+
+from depo.model.formats import ContentFormat, ItemKind, kind_for_format
+from tests.factories.web import make_client
+
+
+class TestGetUploadPage:
+    """GET /upload serves the upload form"""
+
+    def test_returns_200_and_html_content(self, tmp_path):
+        resp = make_client(tmp_path).get(url="/upload")
+        assert resp.status_code == 200
+        assert resp.headers.get("content-type") == "text/html; charset=utf-8"
+
+    def test_returns_expected_html(self, tmp_path):
+        """Returns template markers, form elements & content-type overrides"""
+        resp = make_client(tmp_path).get(url="/upload")
+        assert "<!-- BEGIN: upload.html -->" in resp.text
+        assert "<!-- END: upload.html -->" in resp.text
+        soup = BeautifulSoup(resp.text, "html.parser")
+        assert soup.find("form", attrs={"method": "post", "action": "/upload"})
+        assert soup.find("textarea", attrs={"name": "content"})
+        assert soup.find("select", attrs={"name": "format"})
+        button = soup.find("button", attrs={"type": "submit"})
+        input_submit = soup.find("input", attrs={"type": "submit"})
+        assert button or input_submit
+        assert soup.find_all("optgroup")
+
+    def test_format_select_covers_all_formats(self, tmp_path):
+        """Every ContentFormat has an option, every ItemKind has an optgroup."""
+        soup = BeautifulSoup(make_client(tmp_path).get("/upload").text, "html.parser")
+        select = soup.find("select", attrs={"name": "format"})
+
+        # Auto-detect default exists with empty value
+        assert select is not None
+        auto = select.find("option", attrs={"value": ""})
+        assert auto is not None
+
+        # Map optgroup labels to ItemKind
+        label_to_kind = {
+            "text": ItemKind.TEXT,
+            "image": ItemKind.PICTURE,
+            "link": ItemKind.LINK,
+        }
+        groups = select.find_all("optgroup")
+        group_labels = {g["label"].lower() for g in groups}  # type: ignore
+
+        # Every ItemKind has an optgroup (except LINK — pending URL classification PR)
+        ## TODO: Remove when URL enters pipeline as content
+        _DEFERRED_KINDS = {ItemKind.LINK}
+        for kind in ItemKind:
+            if kind in _DEFERRED_KINDS:
+                continue
+            assert kind in label_to_kind.values(), f"No label mapping for {kind}"
+
+        for label, kind in label_to_kind.items():
+            if kind in _DEFERRED_KINDS:
+                continue
+            assert label in group_labels, f"Missing optgroup for {kind}"
+
+        # Every option maps to the correct kind via kind_for_format
+        seen_formats = set()
+        for group in groups:
+            expected_kind = label_to_kind[group["label"].lower()]  # type: ignore
+            for option in group.find_all("option"):
+                fmt = ContentFormat(option["value"])
+                assert fmt not in seen_formats, f"Duplicate option: {fmt}"
+                seen_formats.add(fmt)
+                assert kind_for_format(fmt) == expected_kind, f"{fmt} in wrong group"
+
+        # Every ContentFormat is represented
+        assert seen_formats == set(ContentFormat), (
+            f"Missing: {set(ContentFormat) - seen_formats}"
+        )
+
+
+class TestRootRedirect:
+    """GET / redirects to /upload.
+
+    # Returns redirect status
+    # Redirects to /upload
+    """
+
+    def test_redirects_to_upload_302(self, tmp_path):
+        """GET / redirects with 302 to /upload"""
+        resp = make_client(tmp_path).get(url="/", follow_redirects=False)
+        assert resp.status_code == 302
+        assert resp.headers.get("location") == "/upload"

--- a/uv.lock
+++ b/uv.lock
@@ -34,6 +34,19 @@ wheels = [
 ]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
+]
+
+[[package]]
 name = "black"
 version = "25.12.0"
 source = { registry = "https://pypi.org/simple" }
@@ -111,6 +124,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "beautifulsoup4" },
     { name = "black" },
     { name = "httpx" },
     { name = "mypy" },
@@ -133,6 +147,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "beautifulsoup4", specifier = ">=4.14.3" },
     { name = "black", specifier = ">=24.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "mypy", specifier = ">=1.10" },
@@ -793,6 +808,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/c5/abd840d4132fd51a12f594934af5eba1d5d27298a6f5b5d6c3be45301caf/ruff-0.14.13-py3-none-win32.whl", hash = "sha256:ef720f529aec113968b45dfdb838ac8934e519711da53a0456038a0efecbd680", size = 12919024, upload-time = "2026-01-15T20:14:43.647Z" },
     { url = "https://files.pythonhosted.org/packages/c2/55/6384b0b8ce731b6e2ade2b5449bf07c0e4c31e8a2e68ea65b3bafadcecc5/ruff-0.14.13-py3-none-win_amd64.whl", hash = "sha256:6070bd026e409734b9257e03e3ef18c6e1a216f0435c6751d7a8ec69cb59abef", size = 14097887, upload-time = "2026-01-15T20:15:01.48Z" },
     { url = "https://files.pythonhosted.org/packages/4d/e1/7348090988095e4e39560cfc2f7555b1b2a7357deba19167b600fdf5215d/ruff-0.14.13-py3-none-win_arm64.whl", hash = "sha256:7ab819e14f1ad9fe39f246cfcc435880ef7a9390d81a2b6ac7e01039083dd247", size = 13080224, upload-time = "2026-01-15T20:14:45.853Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -102,6 +102,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "click" },
     { name = "fastapi" },
+    { name = "jinja2" },
     { name = "pillow" },
     { name = "python-multipart" },
     { name = "rich" },
@@ -123,6 +124,7 @@ dev = [
 requires-dist = [
     { name = "click", specifier = ">=8.3.1" },
     { name = "fastapi", specifier = ">=0.128.5" },
+    { name = "jinja2", specifier = ">=3.1.6" },
     { name = "pillow", specifier = ">=12.1.0" },
     { name = "python-multipart", specifier = ">=0.0.22" },
     { name = "rich", specifier = ">=14.3.2" },
@@ -250,6 +252,18 @@ wheels = [
 ]
 
 [[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
 name = "librt"
 version = "0.7.8"
 source = { registry = "https://pypi.org/simple" }
@@ -311,6 +325,69 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
PR: Browser/HTML Layer

Adds the complete browser interface for depo: upload form, info views,
HTMX interactivity, content negotiation, and error handling.

## What changed

- Static asset serving with bundled HTMX and Pico CSS
- Jinja2 template infrastructure with HTMX fragment detection
- Content negotiation (wants_html) for shortcut routing
- Upload form at GET /upload with textarea and format override dropdown
- HTMX upload flow: POST /upload returns success/error partials
- Split POST /upload (browser form) from POST /api/upload (API)
- Per-type info views: text (inline content), pic (image display), link (clickable URL)
- GET /{code} shortcut redirects based on Accept header
- Error pages: 404, 413 (PayloadTooLargeError), 500 with debug context
- Design language first draft (doc/design/language.md)
- Updated web module docs (doc/module/web.md)

## New files

- src/depo/web/negotiate.py
- src/depo/web/templates.py
- src/depo/util/errors.py
- src/depo/static/ (css, js)
- src/depo/templates/ (base, upload, info/, partials/, errors/)
- tests/web/test_static.py
- tests/web/test_templates.py
- tests/web/test_negotiate_routes.py
- tests/web/test_upload_htmx.py
- tests/web/test_info_page.py
- tests/web/test_errors.py

## Deferred

- Styling/structural primitives (dither patterns, TUI borders) - own PR
- URL classification through pipeline - next PR
- Link optgroup in format dropdown - blocked on URL classification
- Split routes.py into per-concern routers
- Manual route testing with posting collections
