### PR TITLE
Ft: info and error page templates

### DIFF
--- a/doc/design/README.md
+++ b/doc/design/README.md
@@ -71,6 +71,10 @@ IngestOrchestrator coordinates Repository and StorageBackend as siblings.
   - Visual system, color philosophy, structural primitives
   - Palette candidates, template conventions, self-check criteria
 
+- [Styles](./styles.md)
+  - CSS class and token reference, shadow and titlebar mechanics
+  - Pico override notes, known issues
+
 - [Architecture](./architecture.md)
   - System layering, module boundaries, key design rules
 

--- a/doc/design/language.md
+++ b/doc/design/language.md
@@ -157,9 +157,14 @@ These roles are stable even if hues change.
 
 ## Candidate Palettes
 
-Starting with Palette B.
-Palette A is the fallback if B doesn't hold up
-under real usage and fatigue testing.
+Palette A is how we're starting as it's more traditional and
+easier to work with to create a coherent design.
+Its color signals are well understood so it's a good base to start with.
+
+Palette B, or a shifted hue wheel of Palette B,
+is more ideal because its colors make it clear this isn't just an 'app'.
+A task, to play with it as a separate theme with real usage is forthcoming.
+
 Final decision deferred to lived experience.
 
 ### Palette A — Classic Retro (orthodox, conservative)
@@ -273,7 +278,7 @@ Currently mapped to Pico CSS custom properties in static/css/depo.css.
 ### HTMX
 
 Bundled locally, no CDN.
-Scripts loaded at bottom of body.
+Loaded by defer keyword to ensure quick first paint.
 
 Everything served comes from the deployed host.
 
@@ -288,6 +293,7 @@ All templates have boundary markers for debugging and testing:
 
 Full pages extend `base.html`.
 Partials/fragments are standalone (no layout wrapper).
+Those partials are stored in depo/templates/partials/ to clarify their role.
 HTMX requests receive fragments;
 full page loads receive wrapped templates.
 

--- a/doc/design/styles.md
+++ b/doc/design/styles.md
@@ -1,0 +1,65 @@
+# Styles
+
+CSS class and token reference for the depo visual system.
+Implements rules from [design language](./language.md).
+Built on Pico CSS v2.1.1 with overrides in `static/css/depo.css`.
+
+## Token summary
+
+Typography: `--depo-font-mono`, `--depo-size-{heading,body,meta}`,
+`--depo-weight-{body,heading,meta}`.
+
+Dither patterns: `--depo-dither-{diag,check,cross,hstripe}`.
+Fully opaque SVG data URIs, ground `rgb(230,230,230)`, fill `rgb(200,200,200)`.
+
+Structure: `--depo-titlebar-height`, `--depo-bg`, `--depo-border`.
+
+## Class reference
+
+Dither fills: `.dither-diag`, `.dither-check`, `.dither-cross`.
+Borders: `.tui-border` (2px), `.tui-border-heavy` (4px).
+Metadata: `.meta` (small, mono, muted).
+Form grouping: `.window-controls` (flex row).
+
+## Shadows
+
+`.shadow-sm` (11px offset), `.shadow-md` (19px offset).
+Checkerboard `::after` pseudo-element, bordered, `z-index: -1`.
+Stacking context lives on `main`, not the shadow parent.
+`background-position: top left` for bottom-edge tile alignment.
+
+Offsets are manually tuned — border width shifts background origin
+so clean tile multiples don't land. Deeper fix deferred to v0.2.
+
+## Titlebar
+
+`.titlebar` — flex container with horizontal stripe dither.
+`.titlebar-label` — child `<a>`, stretches to fill bar height,
+solid background punchout matching stripe ground color.
+
+Uses `overflow: hidden` to clip. Height via `--depo-titlebar-height`.
+
+## Window
+
+`.window` — bordered container, solid `--depo-bg` background.
+Sits on gray `main` surface. Combine with shadow classes for depth.
+
+## Pico override notes
+
+Pico v2 scopes colors under `:root:not([data-theme=dark])`, not `:root`.
+`base.html` requires `data-theme="light"` on `<html>`.
+Source order wins when specificity matches.
+
+`--pico-primary-background` controls buttons, `--pico-primary` controls links.
+Both plus border/hover/focus variants needed for full control.
+
+`--pico-font-weight` overrides body weight globally.
+Form element fonts set directly — no Pico property for these.
+
+`footer.site-footer` compound selector required to beat Pico's bare `footer`.
+
+## Known issues
+
+High-DPI: 1px SVG bits invisible, `background-size` scaling mandatory.
+Zoom: fractional levels cause sub-pixel artifacts. Clean at 100% and 2x/3x.
+Large-surface dither looked busy — flat grays used instead, dither deferred to v0.2.

--- a/doc/module/README.md
+++ b/doc/module/README.md
@@ -104,17 +104,28 @@ See [cli.md](./cli.md) for interface specifications.
 ### web/
 
 HTTP boundary of the application.
-
 This includes:
 
 - FastAPI app setup
 - routes and handlers
 - request and response schemas
 - dependency wiring
+- Jinja2 templates and static assets
 
 This is the only place FastAPI should appear.
-
 See [web.md](./web.md) for interface specifications.
+
+### templates/
+
+Jinja2 templates served by the web layer.
+This includes:
+
+- page layouts and inheritance hierarchy
+- info page system with shared shell and type partials
+- error pages
+- partials and HTMX fragments
+
+See [templates.md](./templates.md) for structure and conventions.
 
 ### util/
 
@@ -149,6 +160,14 @@ Tests mirror the application structure by responsibility:
 - `tests/repo/`     -> tests for repository behavior
 - `tests/storage/`  -> tests for storage backends
 - `tests/web/`      -> tests for HTTP behavior
+  - `routes/`       -> route selection, status codes, content types
+  - `test_templates.py`       -> base template infrastructure
+  - `test_info_templates.py`  -> info page template structure and content
+  - `test_error_templates.py` -> error page template structure
+
+`tests/factories/` provides shared test helpers:
+model factories (make_link_item, make_text_item, make_pic_item),
+client factories, and render_template for direct Jinja2 template rendering.
 
 Test code should prefer black-box behavior over internal details.
 

--- a/doc/module/templates.md
+++ b/doc/module/templates.md
@@ -1,0 +1,132 @@
+# Templates
+
+Jinja2 templates served via FastAPI.
+Rendered by `web.templates.get_templates()`.
+
+## Structure
+
+```txt
+templates/
+├── base.html                # Full page layout wrapper
+├── upload.html              # Upload form (extends base.html)
+├── theme.html               # Living style reference (extends base.html)
+├── info/
+│   ├── page.html            # Shared info page shell (extends base.html)
+│   ├── link.html            # LinkItem view (extends page.html)
+│   ├── text.html            # TextItem view (extends page.html)
+│   └── pic.html             # PicItem view (extends page.html)
+├── partials/
+│   ├── nav.html             # Titlebar navigation
+│   ├── foot.html            # Site footer
+│   ├── success.html         # Upload success (HTMX fragment)
+│   └── error.html           # Validation error (HTMX fragment)
+└── errors/
+    ├── 404.html             # Not found (extends base.html)
+    └── 500.html             # Internal error (extends base.html)
+```
+
+## Inheritance hierarchy
+
+```txt
+base.html
+├── upload.html
+├── theme.html
+├── info/page.html
+│   ├── info/link.html
+│   ├── info/text.html
+│   └── info/pic.html
+└── errors/
+    ├── 404.html
+    └── 500.html
+```
+
+`base.html` provides the page shell:
+`nav` partial, content block, footer partial.
+
+`info/page.html` provides the info shell:
+window container, shortcode heading, action row,
+payload block, divider, metadata block.
+Child templates fill:
+`{% block payload %}`, `{% block metadata %}`, and `{% block payload_class %}`.
+
+## Info page system
+
+`info/page.html` defines the reading order inside an `article.window.shadow-md`:
+
+1. Shortcode heading (h2.shortcode)
+2. Action row (div.action-row, role="toolbar")
+3. Payload (div#payload, class from payload_class block)
+4. Divider (hr.divider)
+5. Metadata (dl#metadata.meta)
+
+Blocks provided to child templates:
+
+- `payload` -- type-specific content (link anchor, pre>code, img)
+- `metadata` -- type-specific dt/dd pairs inside the dl wrapper
+- `payload_class` -- modifier class (payload--link, payload--text, payload--pic)
+
+Action row contains:
+
+- Copy content button (disabled, deferred)
+- Copy URL button (secondary, data-copy with absolute URL)
+- Copy shortcode button (outline, data-copy with code)
+- Facts anchor (href="#metadata")
+
+Clipboard handling is a script block at the end of info/page.html.
+Delegates via click listener on any element with data-copy attribute.
+
+## Error pages
+
+Both error templates use `section.window.window--error` as their container.
+No action row, no metadata, no payload block.
+
+404: Renders the shortcode in a code.shortcode element with a message
+that the code does not exist or was deleted.
+
+500: Renders a message heading, a paragraph with issues link, and a
+details element (default closed) containing debug info as a dl with
+path, method, and detail.
+
+## Conventions
+
+Template markers use boundary comments for debugging and testing:
+
+```html:jinja2
+    <!-- BEGIN: info/page.html -->
+    <!-- END: info/page.html -->
+```
+
+Child templates note their parent:
+
+```html:jinja2
+    <!-- BEGIN: info/link.html -->
+    <!-- EXTENDS: base.html -->
+```
+
+Block content in child templates uses fragment markers:
+
+```html:jinja2
+    <!-- BEGIN: info/link.html#payload -->
+    <!-- END: info/link.html#payload -->
+```
+
+Shortcode display uses `code.shortcode` as a project-wide convention.
+The shortcode class is functional (tested against), not purely visual.
+
+Partials (`nav`, `footer`, `success`, `error`)
+are standalone fragments with no extends.
+Returned directly for HTMX requests.
+
+## Testing
+
+`render_template(name, ctx)` in `tests/factories`
+renders a named template with a context dict and returns parsed BeautifulSoup.
+Used by `test_info_templates.py` & `test_error_templates.py`.
+
+Info template tests pass a stub request object with `base_url` for
+the absolute URL in the copy URL button.
+The stub is set up in the module-level `_info_page_soup` helper.
+
+Route tests (`test_shortcode.py`) cover template selection only:
+status code, content-type, template marker presence, & shortcode in response.
+Template markup assertions are owned by the template test modules.

--- a/doc/module/web.md
+++ b/doc/module/web.md
@@ -141,60 +141,8 @@ Thin getters pulling from `request.app.state`.
 
 ## Templates
 
-### Structure
-
-```txt
-templates/
-├── base.html                # Full page layout wrapper
-├── upload.html              # Upload form (extends base.html)
-├── info/
-│   ├── text.html            # TextItem info view
-│   ├── pic.html             # PicItem info view
-│   └── link.html            # LinkItem info view
-├── partials/
-│   ├── success.html         # Upload success (HTMX fragment)
-│   └── error.html           # Validation error (HTMX fragment)
-└── errors/
-    ├── 404.html             # Not found page
-    └── 500.html             # Internal error with debug context
-```
-
-### Conventions
-
-__Template markers__ — every template has boundary comments for debugging and testing:
-
-```html
-<!-- BEGIN: template-name.html -->
-...
-<!-- END: template-name.html -->
-```
-
-Child templates note their relationship:
-
-```html
-<!-- BEGIN: upload.html -->
-<!-- EXTENDS: base.html -->
-```
-
-Fragments note their role:
-
-```html
-<!-- BEGIN: partials/success.html (fragment) -->
-```
-
-#### Full pages
-
-Extend `base.html` and fill `{% block content %}`.
-Markers must be inside the block
-(Jinja2 discards content outside blocks in child templates).
-
-#### Partials/fragments
-
-Standalone — no extends, no base layout.
-Returned directly for HTMX requests (`HX-Request` header present).
-
-__Shortcode display__ uses `<code class="shortcode">` as a project-wide convention.
-The `shortcode` class is functional (tested against), not purely visual.
+See [templates.md](./templates.md) for
+template structure, inheritance, conventions, and testing patterns.
 
 ## HTMX Patterns
 

--- a/doc/planning/handoff.md
+++ b/doc/planning/handoff.md
@@ -26,27 +26,24 @@ During the session:
 
 - Stubs, snippets, and instructions over full implementations
 - One task at a time, one question at a time
-- Suggest shell commands for the user to run, don't assume
-  filesystem access
-- Present commit messages as plain text, not in code blocks
-- Don't present code and non-code (like commit messages) in
-  the same block
+- Provide `cc`-piped commands to gather context, don't ask
+  the user to paste. Combine into single commands where possible.
+  grep/sed over cat — never cat whole files unless small and
+  fully needed
+- Track tasks, deferrals, and doc items as they arise
+- Commit messages in code fences, never mixed with other content
 
 Before ending a session:
 
-- Fill out all per-session sections to reflect current state
-- Document any deferrals in the appropriate planning doc
-- Move completed work from planning docs to reference docs
+- Write per-session sections fresh from current session context.
+  Don't carry forward stale content from previous handoffs
+- Copy static sections verbatim, with any updates made during
+  the session
+- Trim completed items from planning docs, move to reference docs
+- Document deferrals in the appropriate planning doc with
+  cross-references
 - Add new session learnings
-- Trim anything that's been resolved
 - Present the completed handoff for the user to copy and persist
-- Trim completed sections from planning docs
-- Use completed planning items to identify which reference
-  docs (design/, module/, others or new ones) need updating
-- Verify per-session sections reflect current state, don't carry
-  forward stale content from previous handoffs
-- Every deferral must have a cross-reference to a planning doc
-- Layer status should only list what changed or has caveats
 
 ## Orientation **[per-session]**
 
@@ -83,12 +80,6 @@ Bugs or broken states only. Not design decisions or future work — those
 are deferrals. Long-lived issues belong in planning docs, not here.
 
 - (issue and how it manifests)
-
-## Known issues **[per-session]**
-
-Current issues only. Long-lived issues belong in planning docs, not here.
-
-- (issue)
 
 ## Test fixtures **[per-session]**
 
@@ -129,16 +120,17 @@ note where it's documented and keep the entry here as a reminder.
   in except chains. **Does this still belong here?**
 - Hardcoded test assertions over dynamic ones to prevent false positives.
 - Test stubs must include module docstring, imports, and spec comments.
-- Be surgical with context requests.
-  - grep/sed over cat
-  - Don't ask for entire files when a few lines will do.
 - Don't re-ask for context already provided in conversation. Track what's been shared.
-- Every shell command must pipe through `cc`, no exceptions unless stated otherwise.
-- Commit messages go in code fences, never bare text.
-- When "stubs" are requested, give stubs.
-  - Don't give implementations unless explicitly asked or it's clearly busywork.
-- Code and non-code (commit messages, prose) go in separate code blocks. Never mix them.
-- Track documentation items as they arise. Don't rely on memory at the end.
+- Pico styles `footer` element directly. Use compound selector
+  (e.g. `footer.site-footer`) to beat its specificity.
+- SVG data URI dither patterns need `background-size` scaling
+  for high-DPI. 1px bits are sub-pixel on retina screens.
+- Shadow `z-index: -1` pseudo-elements fall behind page background
+  unless an ancestor (not the parent) establishes a stacking context.
+- System mono font stacks are sufficient for retro aesthetic —
+  visual identity comes from structural choices, not typeface.
+- Replacing static asset stubs may require users to clear browser
+  cache. Note in release docs.
 
 ## Conventions **[static]**
 
@@ -203,6 +195,14 @@ Implementation modules include class, function, and method signatures
 with docstrings but no implementation unless explicitly asked.
 
 When updating an existing module, only include the stubs being added.
+
+### Non-Python work (CSS, templates, HTML)
+
+Same stub-first principle. Describe what to add, which selectors or
+elements, and where in the file — don't provide full code blocks
+unless explicitly asked or it's clearly busywork. For CSS, name the
+properties and values. For templates, describe the structure and
+classes. The user writes the actual code.
 
 ### Improving this document **[static]**
 

--- a/doc/planning/mvp.md
+++ b/doc/planning/mvp.md
@@ -32,25 +32,23 @@ Ordered by dependency. Each heading is roughly one PR.
 
 ### Browser UI and styling
 
-Targets the final route and handler structure.
-
-- Styling primitives from the design language: dither patterns (1-bit bitmap
-  fills), TUI borders (box-drawing characters), hard-edge dither shadows,
-  typography hierarchy
-- Toggle raw/rendered views (markdown, data formats)
-- Inline metadata panes
-- Apply visual system from [design language](../design/language.md)
-
-Notes (from prior attempt):
-
-- Pico v2 scopes properties under `:root:not([data-theme=dark])`,
-  not `:root`. Overrides must match that selector.
-- `base.html` requires `data-theme="light"` on `<html>`.
-- htmx.min.js is a redirect stub (same issue pico.min.css had),
-  needs replacing with actual bundle before HTMX features work.
-- Palette A (conservative) active. Palette B tuning, attention role
-  consolidation, dark mode, and System 7 purple exploration deferred
-  to post-MVP.
+- Apply visual system to info, error templates
+  - Window containers for all info and error pages
+  - Error color token, error border treatment (left rule)
+  - Reading order: shortcode, action row, payload, metadata
+  - Action row: copy shortcode, copy content URL, facts jump anchor
+  - Metadata dl styling: dt secondary/normal, dd monospace/primary
+  - Content styling: pre/code inset border, image 1px border
+  - 500 details below divider, smaller type
+  - Fix 404 broken p tag
+- Raw/rendered toggle (separate PR)
+  - Toggle control in action row
+  - Document HTMX interaction patterns in doc/design/interactions.md
+  - HX-Request detection, fragment vs full page response
+  - _payload_info.html and _payload_raw.html partials
+  - hx-get, hx-target=#payload, hx-swap, hx-push-url
+- Visual refinement pass: element spacing, hierarchy, container
+    proportions, nav/footer tuning, large-surface background treatment
 
 ### Error handling
 
@@ -93,6 +91,74 @@ Minimal auth to prevent open uploads on the public internet.
 - Item has owner (`uid`) + visibility (`perm`)
 - `/upload` requires auth
 - `uid=0` superuser convention continues until user table exists
+
+### Global Chrome & Layout Realignment (nav / main / footer / base.html)
+
+**Goal:** Make the overall page shell feel like a single calm system surface.
+Prefer structural honesty (borders, spacing, rhythm) over “window/dialog” cosplay.
+Ensure all hierarchy works in pure grayscale; color remains semantic only.
+
+#### 1) Remove false layering
+
+- Avoid “floating dialog” framing for the primary page surface.
+- Use **one primary containment surface** per page (typically `main`),
+  not nested card/window stacks.
+- Keep `.shadow-*` only where it communicates real stacking
+  - otherwise rely on border + spacing.
+
+#### 2) Establish a stable page frame in `base.html`
+
+- Define one consistent layout grid: `header` (nav), `main`, `footer`.
+- Set a single max-width + horizontal padding rule for `main`
+  - so pages don’t invent their own.
+- Standardize vertical rhythm tokens (one spacing scale); remove ad-hoc micro-gaps.
+
+#### 3) Navbar: structural, not expressive
+
+- Navbar exists to orient, not to brand.
+- Prefer hard bottom border (or separator rule) over decorative fills/texture.
+- Keep height minimal; align content to the same width/padding as `main`.
+- Avoid accent surfaces; no gradients; no ornamental “chrome”.
+
+#### 4) Main backdrop: grayscale-first
+
+- Large surfaces remain grayscale; avoid tinted slabs.
+- Ensure main content boundary reads without color: spacing + borders first.
+- Dark mode parity: invert luminance, keep meaning; do not change hue roles.
+
+#### 5) Footer: quiet + factual
+
+- Footer content in secondary tone; low visual weight.
+- Hard separator above footer if needed; no competing blocks.
+- Align footer width/padding with `main` and navbar.
+
+#### 6) Interaction semantics stay semantic
+
+- Keep warm/cool meaning invariant across the shell:
+  - cool = focus/state
+  - warm = attention/interruption
+  - red = failure only
+- Do not use accent color to “decorate” global chrome.
+
+#### 7) Primitive audit (enforce allowed tools)
+
+- Allowed:
+  - spacing,
+  - typography (mono for identifiers),
+  - weight,
+  - sizing steps,
+  - hard borders,
+  - optional dither separators.
+- Disallowed by default:
+  - blur shadows, gradients, large colored surfaces, decorative textures.
+- If a new visual device is introduced
+  - it must justify itself as structure (not vibe).
+
+#### 8) HTMX compatibility (no layout surprises)
+
+- Shell (`header/main/footer`) should remain stable across HTMX swaps.
+- Swaps should target interior regions only;
+  - avoid global reflow by keeping consistent container widths/padding in `base.html`.
 
 ### Manual Testing
 

--- a/doc/planning/mvp.md
+++ b/doc/planning/mvp.md
@@ -32,23 +32,25 @@ Ordered by dependency. Each heading is roughly one PR.
 
 ### Browser UI and styling
 
-- Apply visual system to info, error templates
-  - Window containers for all info and error pages
-  - Error color token, error border treatment (left rule)
-  - Reading order: shortcode, action row, payload, metadata
-  - Action row: copy shortcode, copy content URL, facts jump anchor
-  - Metadata dl styling: dt secondary/normal, dd monospace/primary
-  - Content styling: pre/code inset border, image 1px border
-  - 500 details below divider, smaller type
-  - Fix 404 broken p tag
 - Raw/rendered toggle (separate PR)
   - Toggle control in action row
   - Document HTMX interaction patterns in doc/design/interactions.md
   - HX-Request detection, fragment vs full page response
   - _payload_info.html and _payload_raw.html partials
   - hx-get, hx-target=#payload, hx-swap, hx-push-url
-- Visual refinement pass: element spacing, hierarchy, container
+  - Content copy button:
+    - clipboard API for payload data,
+      - needs endpoint decision for binary content (base64 encoding).
+    - Disabled placeholder already in action row.
+- Support /{code}/raw.{ext} route for external consumers (own PR)
+  - Forums, chat, unfurlers sniff extension for inline rendering
+  - Server routes on code, ignores extension
+  - Update pic template img src
+  - Update test_img_tag_in_payload in test_info_templates.py
+- Visual refinement pass (own PR): element spacing, hierarchy, container
     proportions, nav/footer tuning, large-surface background treatment
+  - Implement CSS rules for classes in markup: window--error,
+      action-row, payload, payload--link/text/pic, divider
 
 ### Error handling
 

--- a/doc/planning/v0.2.md
+++ b/doc/planning/v0.2.md
@@ -43,3 +43,13 @@ Progressive complexity for the upload form.
   - Consolidate attention/attention-pause into single role
   - Dark mode palette (separate from light tuning)
   - System 7 purple as focus color candidate
+- Bundled web fonts (Source Code Pro or similar, ~50-60KB woff2)
+  - System mono sufficient for MVP, font tuning deferred
+  - CDN loading rejected for privacy (self-hosting audience)
+- Dither patterns on large surfaces
+  - Desktop dither concept promising but busy with multiple patterns
+  - Explore density, contrast, and which surfaces get patterns vs flat gray
+  - Pattern size and color tuning per pattern, especially checkerboard
+- Shadow offset rationalization
+  - Border width shifts background origin, clean tile multiples don't land
+  - Manual tuning works but fragile

--- a/src/depo/templates/errors/404.html
+++ b/src/depo/templates/errors/404.html
@@ -1,9 +1,14 @@
 {% extends "base.html" %}
 {% block content %}
-<!-- BEGIN: errors/404.html -->
-<h2>Not found!</h2>
-</p>The shortcode </p>
-<code class="shortcode">{{ code | upper }}</code>
-<p> does not exist or was deleted.</p>
-<!-- END: errors/404.html -->
+<!-- BEGIN: errors/404.html#content -->
+<!-- EXTENDS: base.html -->
+<section class="window window--error">
+  <h2>Not found!</h2>
+  <p>
+    The shortcode
+    <code class="shortcode">{{ code | upper }}</code>
+    does not exist or was deleted.
+  </p>
+</section>
+<!-- END: errors/404.html#content -->
 {% endblock %}

--- a/src/depo/templates/errors/500.html
+++ b/src/depo/templates/errors/500.html
@@ -1,17 +1,20 @@
 {% extends "base.html" %}
 {% block content %}
-<!-- BEGIN: errors/500.html -->
-<h2>{{ message }}</h2>
-<p>An unexpected error occurred. If this persists, please
-  <a href="{{ issues_url }}">report it</a>.
-</p>
-<details>
-  <summary>Debug info</summary>
-  <dl>
-    <dt>Path</dt><dd>{{ path }}</dd>
-    <dt>Method</dt><dd>{{ method }}</dd>
-    <dt>Detail</dt><dd>{{ detail }}</dd>
-  </dl>
-</details>
-<!-- END: errors/500.html -->
+<!-- BEGIN: errors/500.html#content -->
+<!-- EXTENDS: base.html -->
+<section class="window window--error">
+  <h2>{{ message }}</h2>
+  <p>An unexpected error occurred. If this persists, please
+    <a href="{{ issues_url }}">report it</a>.
+  </p>
+  <details>
+    <summary>Debug info</summary>
+    <dl>
+      <dt>Path</dt><dd>{{ path }}</dd>
+      <dt>Method</dt><dd>{{ method }}</dd>
+      <dt>Detail</dt><dd>{{ detail }}</dd>
+    </dl>
+  </details>
+</section>
+<!-- END: errors/500.html#content -->
 {% endblock %}

--- a/src/depo/templates/info/link.html
+++ b/src/depo/templates/info/link.html
@@ -1,10 +1,11 @@
-{% extends "base.html" %}
-{% block content %}
+{% extends "info/page.html" %}
 <!-- BEGIN: info/link.html -->
-<code class="shortcode">{{ item.code | upper }}</code>
-<dl>
-  <dt>URL</dt><dd><a href="{{ item.url }}">{{ item.url }}</a></dd>
-  <dt>Uploaded</dt><dd>{{ item.upload_at }}</dd>
-</dl>
-<!-- END: info/link.html -->
+<!-- EXTENDS: info/page.html -->
+{% block payload %}
+    <a href="{{ item.url }}">{{ item.url }}</a>
 {% endblock %}
+{% block metadata %}
+    <dt>URL</dt><dd>{{ item.url }}</dd>
+    <dt>Uploaded</dt><dd>{{ item.upload_at }}</dd>
+{% endblock %}
+<!-- END: info/link.html -->

--- a/src/depo/templates/info/link.html
+++ b/src/depo/templates/info/link.html
@@ -1,11 +1,15 @@
 {% extends "info/page.html" %}
-<!-- BEGIN: info/link.html -->
-<!-- EXTENDS: info/page.html -->
+{% block payload_class %}payload--link{% endblock %}
 {% block payload %}
-    <a href="{{ item.url }}">{{ item.url }}</a>
+  <!-- BEGIN: info/link.html#payload -->
+  <!-- EXTENDS: info/page.html -->
+  <a href="{{ item.url }}">{{ item.url }}</a>
+  <!-- END: info/link.html#payload -->
 {% endblock %}
 {% block metadata %}
-    <dt>URL</dt><dd>{{ item.url }}</dd>
-    <dt>Uploaded</dt><dd>{{ item.upload_at }}</dd>
+  <!-- BEGIN: info/link.html#metadata -->
+  <!-- EXTENDS: info/page.html -->
+  <dt>URL</dt><dd>{{ item.url }}</dd>
+  <dt>Uploaded</dt><dd>{{ item.upload_at }}</dd>
+  <!-- END: info/link.html#metadata -->
 {% endblock %}
-<!-- END: info/link.html -->

--- a/src/depo/templates/info/page.html
+++ b/src/depo/templates/info/page.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+{% block content %}
+<!-- BEGIN: info/page.html -->
+<!-- EXTENDS: base.html -->
+<article class="window shadow-md">
+  <h2 class="shortcode">{{ item.code | upper }}</h2>
+  <div class="action-row" role="toolbar">
+    <button disabled data-copy="">Copy Content</button>
+    <button class="secondary" data-copy="/{{ item.code }}/raw">Copy URL</button>
+    <button class="outline" data-copy="{{ item.code | upper }}">Copy Code</button>
+    <a href="#metadata">Facts</a>
+  </div>
+  <div class="payload" id="payload">
+    {% block payload %}
+    {% endblock %}
+  </div>
+  <hr class="divider">
+  <dl class="meta" id="metadata">
+    {% block metadata %}
+    {% endblock %}
+  </dl>
+</article>
+<!-- END: info/page.html -->
+{% endblock %}

--- a/src/depo/templates/info/page.html
+++ b/src/depo/templates/info/page.html
@@ -10,7 +10,7 @@
     <button class="outline" data-copy="{{ item.code | upper }}">Copy Code</button>
     <a href="#metadata">Facts</a>
   </div>
-  <div class="payload" id="payload">
+  <div class="payload {% block payload_class %}{% endblock %}" id="payload">
     {% block payload %}
     {% endblock %}
   </div>

--- a/src/depo/templates/info/page.html
+++ b/src/depo/templates/info/page.html
@@ -6,7 +6,10 @@
   <h2 class="shortcode">{{ item.code | upper }}</h2>
   <div class="action-row" role="toolbar">
     <button disabled data-copy="">Copy Content</button>
-    <button class="secondary" data-copy="/{{ item.code }}/raw">Copy URL</button>
+    <button
+      class="secondary"
+      data-copy="{{ request.base_url }}{{ item.code }}/raw"
+    >Copy URL</button>
     <button class="outline" data-copy="{{ item.code | upper }}">Copy Code</button>
     <a href="#metadata">Facts</a>
   </div>
@@ -21,4 +24,11 @@
   </dl>
 </article>
 <!-- END: info/page.html -->
+<!-- TODO: Does base.html need a scripts block? -->
+<script>
+  document.addEventListener('click', (e) => {
+    const btn = e.target.closest('button[data-copy]');
+    if (btn) navigator.clipboard.writeText(btn.dataset.copy);
+  })
+</script>
 {% endblock %}

--- a/src/depo/templates/info/pic.html
+++ b/src/depo/templates/info/pic.html
@@ -1,15 +1,17 @@
-{% extends "base.html" %}
-{% block content %}
-<!-- BEGIN: info/pic.html (extends base.html) -->
-<code class="shortcode">{{ item.code | upper }}</code>
-<dl>
-  <dt>Format</dt><dd>{{ item.format }}</dd>
-  <dt>Size</dt><dd>{{ item.size_b }} bytes</dd>
-  <dt>Dimensions</dt><dd>{{item.width}}x{{item.height}}</dd>
-  <dt>Uploaded</dt><dd>{{ item.upload_at }}</dd>
-</dl>
-<div class="content__container--pic">
-  <img src="/api/{{ item.code }}/raw">
-</div>
-<!-- END: info/pic.html -->
+{% extends "info/page.html" %}
+{% block payload_class %}payload--pic{% endblock %}
+{% block payload %}
+    <!-- BEGIN: info/pic.html#payload -->
+    <!-- EXTENDS: info/page.html -->
+    <img src="/{{ item.code }}/raw">
+    <!-- END: info/pic.html#payload -->
+{% endblock %}
+{% block metadata %}
+    <!-- BEGIN: info/pic.html#metadata -->
+    <!-- EXTENDS: info/page.html -->
+    <dt>Format</dt><dd>{{ item.format }}</dd>
+    <dt>Size</dt><dd>{{ item.size_b }} bytes</dd>
+    <dt>Dimensions</dt><dd>{{ item.width }}x{{ item.height }}</dd>
+    <dt>Uploaded</dt><dd>{{ item.upload_at }}</dd>
+    <!-- END: info/pic.html#metadata -->
 {% endblock %}

--- a/src/depo/templates/info/text.html
+++ b/src/depo/templates/info/text.html
@@ -1,15 +1,16 @@
-{% extends "base.html" %}
-{% block content %}
-<!-- BEGIN: info/text.html (extends base.html) -->
-<!-- Rendered text content + metadata -->
-<code class="shortcode">{{ item.code | upper }}</code>
-<dl>
-  <dt>Format</dt><dd>{{ item.format }}</dd>
-  <dt>Size</dt><dd>{{ item.size_b }} bytes</dd>
-  <dt>Uploaded</dt><dd>{{ item.upload_at }}</dd>
-</dl>
-<pre class="content__container--text">
-  <code>{{ content }}</code>
-</pre>
-<!-- END: info/text.html -->
+{% extends "info/page.html" %}
+{% block payload_class %}payload--text{% endblock %}
+{% block payload %}
+  <!-- BEGIN: info/text.html#payload -->
+  <pre><code>
+    {{ content }}
+  </code></pre>
+  <!-- END: info/text.html#payload -->
+{% endblock %}
+{% block metadata %}
+    <!-- BEGIN: info/text.html#metadata -->
+    <dt>Format</dt><dd>{{ item.format }}</dd>
+    <dt>Size</dt><dd>{{ item.size_b }} bytes</dd>
+    <dt>Uploaded</dt><dd>{{ item.upload_at }}</dd>
+    <!-- END: info/text.html#metadata -->
 {% endblock %}

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -15,6 +15,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
+from bs4 import BeautifulSoup as BSoup
 from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
 
@@ -23,6 +24,7 @@ from depo.model.enums import ContentFormat, ItemKind, Visibility
 from depo.model.item import LinkItem, PicItem, TextItem
 from depo.service.orchestrator import PersistResult
 from depo.web.app import app_factory
+from depo.web.templates import get_templates
 
 from .models import (
     make_item,
@@ -126,3 +128,10 @@ def make_persist_result(
             format=ContentFormat.PLAINTEXT,
         )
     return PersistResult(item=item, created=created)
+
+
+def render_template(name: str, ctx: dict | None = None) -> "BSoup":
+    """Render a Jinja2 template by name with context, return parsed soup."""
+
+    html = get_templates().env.get_template(name).render(**(ctx or {}))
+    return BSoup(html, "html.parser")

--- a/tests/web/routes/test_shortcode.py
+++ b/tests/web/routes/test_shortcode.py
@@ -94,6 +94,7 @@ class TestGetInfo:
 class TestInfoPageText:
     """GET /{code}/info for TextItem"""
 
+    @pytest.mark.skip(reason="Refactor bc test_info_page handles the rendering tests")
     def test_response(self, t_seeded):
         """Text info page returns correct template, shortcode, content, and metadata."""
         resp = t_seeded.browser.get(f"/{t_seeded.txt.code}/info")
@@ -118,6 +119,7 @@ class TestInfoPageText:
 class TestInfoPagePic:
     """GET /{code}/info for PicItem"""
 
+    @pytest.mark.skip(reason="Refactor bc test_info_page handles the rendering tests")
     def test_response(self, t_seeded):
         """Text info page returns correct template, shortcode, content, and metadata."""
         resp = t_seeded.browser.get(f"/{t_seeded.pic.code}/info")
@@ -143,6 +145,7 @@ class TestInfoPagePic:
 class TestInfoPageLink:
     """GET /{code}/info for LinkItem"""
 
+    @pytest.mark.skip(reason="Refactor bc test_info_page handles the rendering tests")
     def test_response(self, t_seeded):
         """Link info page returns correct template, shortcode, and clickable URL."""
         resp = t_seeded.browser.get(f"/{t_seeded.link.code}/info")

--- a/tests/web/routes/test_shortcode.py
+++ b/tests/web/routes/test_shortcode.py
@@ -111,6 +111,11 @@ class TestInfoPage:
         resp = t_seeded.browser.get(f"/{t_seeded.link.code}/info")
         self._assert_info_page(resp, "link.html", t_seeded.link.code)
 
+    def test_copy_url_absolute(self, t_seeded):
+        """Copy URL button has absolute URL."""
+        resp = t_seeded.browser.get(f"/{t_seeded.txt.code}/info")
+        assert 'data-copy="http' in resp.text
+
 
 class TestInfoPageNotFound:
     """GET /{code}/info for unknown code"""

--- a/tests/web/routes/test_shortcode.py
+++ b/tests/web/routes/test_shortcode.py
@@ -10,7 +10,6 @@ License: Apache-2.0
 """
 
 import pytest
-from bs4 import BeautifulSoup
 
 
 class TestItem:
@@ -91,78 +90,26 @@ class TestGetInfo:
         assert t_client.get("/ZZZZZZZZ/info").status_code == 404
 
 
-class TestInfoPageText:
-    """GET /{code}/info for TextItem"""
+class TestInfoPage:
+    """GET /{code}/info serves correct template per item type."""
 
-    @pytest.mark.skip(reason="Refactor bc test_info_page handles the rendering tests")
-    def test_response(self, t_seeded):
-        """Text info page returns correct template, shortcode, content, and metadata."""
+    def _assert_info_page(self, resp, template: str, code: str):
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("text/html")
+        assert f"<!-- BEGIN: info/{template}" in resp.text
+        assert code in resp.text
+
+    def test_text(self, t_seeded):
         resp = t_seeded.browser.get(f"/{t_seeded.txt.code}/info")
-        msg = "Response is not HTML"
-        assert resp.headers.get("content-type", "").startswith("text/html"), msg
-        assert resp.status_code == 200
-        assert "<!-- BEGIN: info/text.html" in resp.text
-        assert "<!-- END: info/text.html -->" in resp.text
-        assert "<!-- BEGIN: base.html" in resp.text, "Page not wrapped in base template"
-        soup = BeautifulSoup(resp.content, "html.parser")
-        code_el = soup.find(class_="shortcode")
-        dts = {dt.text: dt.find_next_sibling("dd").text for dt in soup.find_all("dt")}  # type: ignore
-        assert code_el is not None
-        assert t_seeded.txt.code in code_el.text
-        assert "Hello, World!" in resp.text
-        assert "Format" in dts
-        assert dts["Format"] == t_seeded.txt.format
-        assert dts["Size"] == f"{t_seeded.txt.size_b} bytes"
-        assert "Uploaded" in dts
+        self._assert_info_page(resp, "text.html", t_seeded.txt.code)
 
-
-class TestInfoPagePic:
-    """GET /{code}/info for PicItem"""
-
-    @pytest.mark.skip(reason="Refactor bc test_info_page handles the rendering tests")
-    def test_response(self, t_seeded):
-        """Text info page returns correct template, shortcode, content, and metadata."""
+    def test_pic(self, t_seeded):
         resp = t_seeded.browser.get(f"/{t_seeded.pic.code}/info")
-        assert resp.status_code == 200
-        assert "<!-- BEGIN: info/pic.html" in resp.text
-        assert "<!-- END: info/pic.html -->" in resp.text
-        assert "<!-- BEGIN: base.html" in resp.text, "Page not wrapped in base template"
-        soup = BeautifulSoup(resp.content, "html.parser")
-        code_el = soup.find(class_="shortcode")
-        dts = {dt.text: dt.find_next_sibling("dd").text for dt in soup.find_all("dt")}  # type: ignore
-        img_el = soup.find("img")
-        assert code_el is not None
-        assert t_seeded.pic.code in code_el.text
-        assert img_el is not None
-        assert f"/api/{t_seeded.pic.code}/raw" in img_el["src"]
-        assert "Format" in dts
-        assert dts["Format"] == "jpg"
-        assert dts["Size"] == f"{t_seeded.pic.size_b} bytes"
-        assert "Uploaded" in dts
-        assert dts["Dimensions"] == f"{t_seeded.pic.width}x{t_seeded.pic.height}"
+        self._assert_info_page(resp, "pic.html", t_seeded.pic.code)
 
-
-class TestInfoPageLink:
-    """GET /{code}/info for LinkItem"""
-
-    @pytest.mark.skip(reason="Refactor bc test_info_page handles the rendering tests")
-    def test_response(self, t_seeded):
-        """Link info page returns correct template, shortcode, and clickable URL."""
+    def test_link(self, t_seeded):
         resp = t_seeded.browser.get(f"/{t_seeded.link.code}/info")
-        assert resp.status_code == 200
-        assert "<!-- BEGIN: info/link.html" in resp.text
-        assert "<!-- END: info/link.html -->" in resp.text
-        assert "<!-- BEGIN: base.html" in resp.text
-        soup = BeautifulSoup(resp.content, "html.parser")
-        code_el = soup.find(class_="shortcode")
-        assert code_el is not None
-        assert t_seeded.link.code in code_el.text
-        link_el = soup.find("a", href=t_seeded.link.url)
-        assert link_el is not None
-        assert t_seeded.link.url in link_el.text
-        dts = {dt.text: dt.find_next_sibling("dd").text for dt in soup.find_all("dt")}  # type: ignore
-        assert "URL" in dts
-        assert "Uploaded" in dts
+        self._assert_info_page(resp, "link.html", t_seeded.link.code)
 
 
 class TestInfoPageNotFound:

--- a/tests/web/test_error_templates.py
+++ b/tests/web/test_error_templates.py
@@ -1,0 +1,85 @@
+# tests/web/test_error_templates.py
+"""
+Tests for error page templates (404, 500).
+Author: Marcus Grant
+Created: 2026-02-25
+License: Apache-2.0
+"""
+
+from tests.factories import render_template
+
+
+def _404_select(selector: str):
+    """Render 404 template w/ stub context, return first CSS match."""
+    return render_template("errors/404.html", {"code": "abc123"}).select_one(selector)
+
+
+_500_MSG = "Something went wrong"
+_500_DET = "test error detail"
+_500_URL = "https://github.com/marcus-grant/depo/issues"
+
+
+def _500_select(selector: str):
+    """Render 500 template w/ stub context, return first CSS match."""
+    return render_template(
+        "errors/500.html",
+        {
+            "message": _500_MSG,
+            "path": "/test",
+            "method": "GET",
+            "detail": _500_DET,
+            "issues_url": _500_URL,
+        },
+    ).select_one(selector)
+
+
+class TestError404:
+    """404 error template."""
+
+    def select(self, selector):
+        """Helper alias for selecting from 404 template soup."""
+        return _404_select(selector)
+
+    def test_window_error_container(self):
+        """Renders inside a .window container."""
+        assert self.select("section.window.window--error") is not None
+
+    def test_shortcode_in_error_text(self):
+        """Has shortcode in code tag in error message."""
+        assert self.select("section.window code.shortcode") is not None
+        assert self.select("section.window code.shortcode").text == "ABC123"  # type: ignore
+
+    def test_no_action_or_metadata(self):
+        """Nas no action row, metadata, or meta elements (info pages only)."""
+        assert self.select("section.window .action-row") is None
+        assert self.select("section.window .metadata") is None
+        assert self.select("section.window .meta") is None
+
+
+class TestError500:
+    """500 error template."""
+
+    def select(self, selector):
+        """Helper alias for selecting from 500 template soup."""
+        return _500_select(selector)
+
+    def test_window_error_container(self):
+        """Renders inside a .window container."""
+        assert self.select("section.window.window--error") is not None
+
+    def test_message_in_error_text(self):
+        """Renders message text in .error-text element."""
+        assert self.select("section.window--error h2") is not None
+        assert self.select("section.window--error h2").text == _500_MSG  # type: ignore
+
+    def test_debug_details(self):
+        """Debug details block has summary, path, and method."""
+        details = self.select("section.window--error details")
+        assert details is not None, "No <details> element found"
+        assert details.find("summary") is not None, "No <summary> in details"
+        assert "GET" in details.text and "/test" in details.text
+
+    def test_issues_link(self):
+        """Issues link present for error reporting."""
+        url_selector = f"section.window--error a[href='{_500_URL}']"
+        assert self.select(url_selector) is not None

--- a/tests/web/test_info_templates.py
+++ b/tests/web/test_info_templates.py
@@ -16,6 +16,7 @@ from tests.factories.payloads import gen_image
 
 def _info_page_soup(template: str, item: Item, **ctx) -> BSoup:
     """Helper to render info page template and return soup."""
+    ctx.setdefault("request", type("Req", (), {"base_url": "http://test/"})())
     return render_template(template, {"item": item, **ctx})
 
 
@@ -92,6 +93,10 @@ class TestInfoStructure:
     def test_action_facts_jump(self):
         """Facts anchor links to metadata section."""
         assert self.select(".action-row a[href='#metadata']") is not None
+
+    def test_clipboard_script(self):
+        """Clipboard handler script is present."""
+        assert self.select("script") is not None
 
 
 class TestInfoLink:

--- a/tests/web/test_info_templates.py
+++ b/tests/web/test_info_templates.py
@@ -8,86 +8,166 @@ License: Apache-2.0
 
 from bs4 import BeautifulSoup as BSoup
 
+from depo.model.item import Item
 from tests.factories import render_template
-from tests.factories.models import make_link_item
+from tests.factories.models import make_link_item, make_pic_item, make_text_item
+from tests.factories.payloads import gen_image
 
 
-def _info_link_soup() -> BSoup:
-    """Helper to render link info template and return soup."""
-    return render_template("info/link.html", {"item": make_link_item()})
+def _info_page_soup(template: str, item: Item, **ctx) -> BSoup:
+    """Helper to render info page template and return soup."""
+    return render_template(template, {"item": item, **ctx})
+
+
+def _link_info_soup_select(selector: str):
+    """Create BeautifulSoup of rendered LinkItem info template and select element"""
+    return _info_page_soup("info/link.html", make_link_item()).select_one(selector)
+
+
+_TXT_DATA = "Hello, world!"
+
+
+def _text_info_soup_select(selector: str):
+    """Create BeautifulSoup of rendered TextItem info template and select element"""
+    args = ("info/text.html", make_text_item())
+    return _info_page_soup(*args, content=_TXT_DATA).select_one(selector)
+
+
+_PIC_DATA = gen_image("png", 32, 24)  # Red image data
+
+
+def _pic_info_soup_select(selector: str):
+    """Create BeautifulSoup of rendered PicItem info template and select element"""
+    args = ("info/pic.html", make_pic_item())
+    return _info_page_soup(*args, content=_PIC_DATA).select_one(selector)
 
 
 class TestInfoStructure:
     """Shared window structure across all info templates."""
 
-    def info_select(self, selector: str):
-        return _info_link_soup().select_one(selector)
+    def select(self, selector):
+        """Alias for the same selection of info soup on every test"""
+        return _link_info_soup_select(selector)
 
     def test_window_container(self):
         """Info page content renders inside a .window container."""
-        assert self.info_select("article.window") is not None
+        assert self.select("article.window") is not None
 
     def test_code_first(self):
         """Renders shortcode as first child of .window."""
-        assert self.info_select("article.window > .shortcode") is not None
+        assert self.select("article.window > .shortcode") is not None
 
     def test_action_after_code(self):
         """Has .action-row after shortcode."""
-        assert self.info_select("article.window > .shortcode + .action-row") is not None
+        assert self.select("article.window > .shortcode + .action-row") is not None
 
     def test_payload_after_action(self):
         """Has #payload container after action row."""
-        assert self.info_select("article.window > .action-row + #payload") is not None
+        assert self.select("article.window > .action-row + #payload") is not None
 
     def test_payload_meta_divider(self):
         """Has divider between payload and metadata."""
-        assert self.info_select("#payload + hr.divider") is not None
+        assert self.select("#payload + hr.divider") is not None
 
     def test_metadata_after_divider(self):
         """Has #metadata dl after divider."""
-        assert self.info_select("hr.divider + dl#metadata") is not None
+        assert self.select("hr.divider + dl#metadata") is not None
 
     def test_action_copy_content_disabled(self):
         """Copy content button exists but is disabled."""
-        btn = self.info_select(".action-row button[disabled]")
-        assert btn is not None
+        assert self.select(".action-row button[disabled]") is not None
 
     def test_action_copy_url(self):
         """Copy URL button carries raw URL for clipboard."""
-        btn = self.info_select(".action-row button.secondary[data-copy]")
+        btn = self.select(".action-row button.secondary[data-copy]")
         assert btn is not None
         assert "/raw" in btn.get("data-copy", "")  # type: ignore
 
     def test_action_copy_shortcode(self):
         """Copy shortcode button carries code value for clipboard."""
-        btn = self.info_select(".action-row button.outline[data-copy]")
+        btn = self.select(".action-row button.outline[data-copy]")
         assert btn is not None
         assert btn.get("data-copy") != ""
 
     def test_action_facts_jump(self):
         """Facts anchor links to metadata section."""
-        assert self.info_select(".action-row a[href='#metadata']") is not None
+        assert self.select(".action-row a[href='#metadata']") is not None
 
 
 class TestInfoLink:
     """Link-specific info template content."""
 
-    # should render URL in payload
-    # should render upload_at in metadata
-    ...
+    def select(self, selector):
+        """Alias for the same selection of info soup on every test"""
+        return _link_info_soup_select(selector)
+
+    def test_url_in_payload(self):
+        """Renders URL in payload section."""
+        assert self.select("#payload a") is not None
+        assert self.select("#payload a").text == "https://example.com"  # type: ignore
+
+    def test_upload_at_in_metadata(self):
+        """Renders upload timestamp in metadata."""
+        dl = self.select("dl#metadata")
+        assert dl is not None
+        assert any(w in dl.text.lower() for w in ("upload", "creat", "date", "time"))
+
+    def test_payload_modifier(self):
+        """Payload has type-specific class."""
+        assert self.select("#payload.payload--link") is not None
 
 
 class TestInfoText:
     """Text-specific info template content."""
 
-    # should render content in pre>code inside payload
-    # should render format, size_b, upload_at in metadata
-    ...
+    def select(self, selector):
+        """Alias for the same selection of text info soup on every test"""
+        return _text_info_soup_select(selector)
+
+    def test_content_in_pre_code_payload(self):
+        """Renders text content inside <pre><code> in payload."""
+        el = self.select("#payload pre code")
+        assert el is not None
+        assert _TXT_DATA in el.text
+
+    def test_metadata_fields_present(self):
+        """Renders format, size, upload timestamp in metadata."""
+        dl = self.select("dl#metadata")
+        assert dl is not None
+        text = dl.text.lower()
+        assert any(w in text for w in ("format", "type"))
+        assert any(w in text for w in ("size", "bytes", "length"))
+        assert any(w in text for w in ("upload", "created", "date", "time"))
+
+    def test_payload_modifier(self):
+        """Payload has type-specific class."""
+        assert self.select("#payload.payload--text") is not None
 
 
 class TestInfoPic:
     """Pic-specific info template content."""
 
-    # should render img tag in payload with correct src
-    # should render format, size_b, dimensions, upload_at in metadata
-    ...
+    def select(self, selector):
+        """Alias for the same selection of pic info soup on every test"""
+        return _pic_info_soup_select(selector)
+
+    def test_img_tag_in_payload(self):
+        """Renders <img> tag in payload with correct src."""
+        img = self.select("#payload img")
+        assert img is not None
+        assert img.get("src", "") != ""
+        assert "/raw" in img.get("src", "")  # type: ignore
+
+    def test_metadata_fields_present(self):
+        """Renders format, size, dimensions, upload timestamp in metadata."""
+        dl = self.select("dl#metadata")
+        assert dl is not None
+        text = dl.text.lower()
+        assert any(w in text for w in ("format", "type"))
+        assert any(w in text for w in ("size", "bytes", "length"))
+        assert any(w in text for w in ("dim", "res", "width", "height"))
+        assert any(w in text for w in ("upload", "created", "date", "time"))
+
+    def test_payload_modifier(self):
+        """Payload has type-specific class."""
+        assert self.select("#payload.payload--pic") is not None

--- a/tests/web/test_info_templates.py
+++ b/tests/web/test_info_templates.py
@@ -1,0 +1,93 @@
+# tests/web/test_info_templates.py
+"""
+Tests for info page templates (link, text, pic).
+Author: Marcus Grant
+Created: 2026-02-25
+License: Apache-2.0
+"""
+
+from bs4 import BeautifulSoup as BSoup
+
+from tests.factories import render_template
+from tests.factories.models import make_link_item
+
+
+def _info_link_soup() -> BSoup:
+    """Helper to render link info template and return soup."""
+    return render_template("info/link.html", {"item": make_link_item()})
+
+
+class TestInfoStructure:
+    """Shared window structure across all info templates."""
+
+    def info_select(self, selector: str):
+        return _info_link_soup().select_one(selector)
+
+    def test_window_container(self):
+        """Info page content renders inside a .window container."""
+        assert self.info_select("article.window") is not None
+
+    def test_code_first(self):
+        """Renders shortcode as first child of .window."""
+        assert self.info_select("article.window > .shortcode") is not None
+
+    def test_action_after_code(self):
+        """Has .action-row after shortcode."""
+        assert self.info_select("article.window > .shortcode + .action-row") is not None
+
+    def test_payload_after_action(self):
+        """Has #payload container after action row."""
+        assert self.info_select("article.window > .action-row + #payload") is not None
+
+    def test_payload_meta_divider(self):
+        """Has divider between payload and metadata."""
+        assert self.info_select("#payload + hr.divider") is not None
+
+    def test_metadata_after_divider(self):
+        """Has #metadata dl after divider."""
+        assert self.info_select("hr.divider + dl#metadata") is not None
+
+    def test_action_copy_content_disabled(self):
+        """Copy content button exists but is disabled."""
+        btn = self.info_select(".action-row button[disabled]")
+        assert btn is not None
+
+    def test_action_copy_url(self):
+        """Copy URL button carries raw URL for clipboard."""
+        btn = self.info_select(".action-row button.secondary[data-copy]")
+        assert btn is not None
+        assert "/raw" in btn.get("data-copy", "")  # type: ignore
+
+    def test_action_copy_shortcode(self):
+        """Copy shortcode button carries code value for clipboard."""
+        btn = self.info_select(".action-row button.outline[data-copy]")
+        assert btn is not None
+        assert btn.get("data-copy") != ""
+
+    def test_action_facts_jump(self):
+        """Facts anchor links to metadata section."""
+        assert self.info_select(".action-row a[href='#metadata']") is not None
+
+
+class TestInfoLink:
+    """Link-specific info template content."""
+
+    # should render URL in payload
+    # should render upload_at in metadata
+    ...
+
+
+class TestInfoText:
+    """Text-specific info template content."""
+
+    # should render content in pre>code inside payload
+    # should render format, size_b, upload_at in metadata
+    ...
+
+
+class TestInfoPic:
+    """Pic-specific info template content."""
+
+    # should render img tag in payload with correct src
+    # should render format, size_b, dimensions, upload_at in metadata
+    ...


### PR DESCRIPTION
# Info and error page templates

## Summary

Implements the template structure for info and error pages.
Shared info page shell with type-specific partials, error page
containers, action row with clipboard copy, and supporting
test infrastructure.

## Changes

- info/page.html: shared shell with shortcode, action row,
  payload/metadata blocks, divider
- info/link.html, text.html, pic.html: type-specific partials
  extending page.html
- errors/404.html: section.window--error, fixed broken p tag
- errors/500.html: section.window--error, debug details block
- Action row: copy URL, copy shortcode (clipboard via data-copy),
  disabled copy content placeholder, facts jump anchor
- Clipboard click handler in info/page.html
- render_template factory in tests/factories
- TestInfoStructure, TestInfoLink, TestInfoText, TestInfoPic
- TestError404, TestError500
- Refactored TestInfoPage in route tests to check template
  selection only
- Refactored TestBaseTemplate to use shared factory

## New files

- src/depo/templates/info/page.html
- tests/web/test_info_templates.py
- tests/web/test_error_templates.py
- doc/module/templates.md

## Deferred

- Content copy button: needs endpoint decision for binary
- CSS rules for new classes: window--error, action-row, payload,
  payload--link/text/pic, divider
- /{code}/raw.{ext} extension-aware URLs

## Notes

- Info page reading order: shortcode, action row, payload,
  metadata (content-first, not inspector-first)
- Template markup assertions owned by template test modules,
  route tests check selection only
